### PR TITLE
Add __unicode__ methods to allow proper representation

### DIFF
--- a/conf_site/proposals/models.py
+++ b/conf_site/proposals/models.py
@@ -30,7 +30,12 @@ class TalkProposal(Proposal):
     class Meta:
         verbose_name = "talk proposal"
 
+    def __unicode__(self):
+        return self.title
 
 class TutorialProposal(Proposal):
     class Meta:
         verbose_name = "tutorial proposal"
+
+    def __unicode__(self):
+        return self.title


### PR DESCRIPTION
This fixes #24. cc @brittainhard