### PR TITLE
have seattle.pydata.org show the landing page

### DIFF
--- a/conf_site/templates/seattle2015/index.html
+++ b/conf_site/templates/seattle2015/index.html
@@ -76,7 +76,7 @@
         <ol>
           <li>Register for an account on pydata <a href="{% url "account_signup" %}">here</a>.</li>
           <li>Create a speaker profile.</li>
-          <li>Submit an abstract of your talk or tutorial <a href="proposals/submit/">here</a>.</li>
+          <li>Submit an abstract of your talk or tutorial <a href="{% url "proposal_submit" %}">here</a>.</li>
         </ol>
 
         <h5>Information</h5>

--- a/conf_site/urls.py
+++ b/conf_site/urls.py
@@ -14,7 +14,7 @@ WIKI_SLUG = r"(([\w-]{2,})(/[\w-]{2,})*)"
 urlpatterns = patterns(
     "",
     # url(r"^$", TemplateView.as_view(template_name="pydata-home/index.html"), name="index"),
-    url(r"^seattle2015/$", TemplateView.as_view(template_name="seattle2015/index.html"), name="seattle_index"),
+    url(r"^$", TemplateView.as_view(template_name="seattle2015/index.html"), name="seattle_index"),
     url(r"^seattle2015/home/$", TemplateView.as_view(template_name="homepage.html"), name="home"),
     url(r"^seattle2015/admin/", include(admin.site.urls)),
 

--- a/deploy/seattle2015-site.conf.j2
+++ b/deploy/seattle2015-site.conf.j2
@@ -15,7 +15,7 @@ server {
         alias /www/conf_site/source/public/static/;
     }
 
-    location /seattle2015 {
+    location / {
         proxy_pass http://127.0.0.1:8001;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Host $server_name;

--- a/fabfile.py
+++ b/fabfile.py
@@ -50,8 +50,8 @@ env.webuser = 'seattle2015'
 def production():
     """ Use production. Preface tasks with production to run in production. """
     env.environment = 'production'
-    env.hosts = ['confsite.pydata.org']
-    env.server_name = 'confsite.pydata.org'
+    env.hosts = ['seattle.pydata.org']
+    env.server_name = 'seattle.pydata.org'
     env.requirements = 'production.txt'
 
 @task


### PR DESCRIPTION
Needs review.

This change makes seattle.pydata.org show the current seattle2015/ page. I changed the forwarding in the nginx site conf and also updated a link in the landing page that was hardcoded.