### PR TITLE
fix schedule grid display for presentations

### DIFF
--- a/conf_site/templates/schedule/_grid.html
+++ b/conf_site/templates/schedule/_grid.html
@@ -13,7 +13,9 @@
                 <td class="time">{{ row.time|date:"h:iA" }}</td>
                 {% for slot in row.slots %}
                     <td class="slot slot-{{ slot.kind.label }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
-                        {% if slot.kind.label == "talk" or slot.kind.label == "tutorial" %}
+                      {# this is a kludge until the slot.kind model has a property #}
+                      {# to distinguish a presentation from a non-presentation slot #}
+                        {% if slot.kind.label in "Track 4 Track 3 Track 2 Track 1 Tutorial Track 4 Tutorial Track 3 Tutorial Track 2 Tutorial Track 1" %}
                             {% if not slot.content %}
                             {% else %}
                                 <span class="title">


### PR DESCRIPTION
Schedules weren't showing properly in the grid due to the template hard
coding a check for the slot kind as 'tutorial' or 'talk'. The PyData schedule
has slot kinds as 'Track 1', 'Tutorial Track 1', etc.