### PR TITLE
Redirect [conference].pydata.org.

### DIFF
--- a/ansible/group_vars/vagrant
+++ b/ansible/group_vars/vagrant
@@ -1,7 +1,8 @@
-database_user: vagrant
-django_database: vagrant
+conference_identifier: vagrant
+database_user: "{{ conference_identifier }}"
+django_database: "{{ conference_identifier }}"
 environment_type: dev
-subdirectory: /vagrant
+subdirectory: /{{ conference_identifier }}
 website_domain: localhost
 website_port: 8080
 website_url: http://{{ website_domain }}:{{ website_port }}{{ subdirectory }}

--- a/ansible/host_vars/berlin2016
+++ b/ansible/host_vars/berlin2016
@@ -1,5 +1,6 @@
-database_user: berlin2016
-django_database: berlin2016
-subdirectory: /berlin2016
+conference_identifier: berlin2016
+database_user: "{{ conference_identifier }}"
+django_database: "{{ conference_identifier }}"
+subdirectory: /{{ conference_identifier }}
 website_domain: pydata.org
 website_url: http://pydata.org{{ subdirectory }}

--- a/ansible/host_vars/london2016
+++ b/ansible/host_vars/london2016
@@ -1,5 +1,6 @@
-database_user: london2016
-django_database: london2016
-subdirectory: /london2016
+conference_identifier: london2016
+database_user: "{{ conference_identifier }}"
+django_database: "{{ conference_identifier }}"
+subdirectory: /{{ conference_identifier }}
 website_domain: pydata.org
 website_url: http://pydata.org{{ subdirectory }}

--- a/ansible/host_vars/madrid2016
+++ b/ansible/host_vars/madrid2016
@@ -1,5 +1,6 @@
-database_user: madrid2016
-django_database: madrid2016
-subdirectory: /madrid2016
+conference_identifier: madrid2016
+database_user: "{{ conference_identifier }}"
+django_database: "{{ conference_identifier }}"
+subdirectory: /{{ conference_identifier }}
 website_domain: pydata.org
 website_url: http://pydata.org{{ subdirectory }}

--- a/ansible/roles/web/templates/nginx-site.conf
+++ b/ansible/roles/web/templates/nginx-site.conf
@@ -1,5 +1,12 @@
 server {
     listen 80;
+    server_name {{ conference_identifier }}.pydata.org;
+    rewrite ^ {{ website_url }}$request_uri? redirect;
+}
+
+
+server {
+    listen 80;
     server_name {{ website_domain }};
     client_max_body_size 10M;
 


### PR DESCRIPTION
Update Ansible host variables and the nginx configuration so that incoming requests to `[conference].pydata.org` will redirect to the conference's designated website (normally `pydata.org/[conference]`).

**Note**: this will probably cause a redirect loop if the conference's canonical website is `[conference].pydata.org`.