### PR TITLE
Improve handling of room information.

### DIFF
--- a/conf_site/templates/symposion/schedule/presentation_detail.html
+++ b/conf_site/templates/symposion/schedule/presentation_detail.html
@@ -11,6 +11,9 @@
         <h4>
             {{ presentation.slot.day.date|date:"l" }}
             {{ presentation.slot.start}}&ndash;{{ presentation.slot.end }}
+            {% if presentation.slot.rooms %}
+                in {{ presentation.slot.rooms|join:", " }}
+            {% endif %}
         </h4>
     {% endif %}
     <h2>{{ presentation.title }}</h2>

--- a/conf_site/templates/symposion/schedule/schedule_list.html
+++ b/conf_site/templates/symposion/schedule/schedule_list.html
@@ -40,8 +40,9 @@
                         <h4>
                             {{ presentation.slot.day.date|date:"l" }}
                             {{ presentation.slot.start}}&ndash;{{ presentation.slot.end }}
-                            in
-                            {{ presentation.slot.rooms|join:", " }}
+                            {% if presentation.slot.rooms %}
+                                in {{ presentation.slot.rooms|join:", " }}
+                            {% endif %}
                         </h4>
                     {% endif %}
                 </div>

--- a/conf_site/templates/symposion/speakers/speaker_profile.html
+++ b/conf_site/templates/symposion/speakers/speaker_profile.html
@@ -29,8 +29,9 @@
                     <p>
                         {{ presentation.slot.day.date|date:"l" }}
                         {{ presentation.slot.start}}&ndash;{{ presentation.slot.end }}
-                        in
-                        {{ presentation.slot.rooms|join:", " }}
+                        {% if presentation.slot.rooms %}
+                            in {{ presentation.slot.rooms|join:", " }}
+                        {% endif %}
                     </p>
                 {% endif %}
             {% empty %}


### PR DESCRIPTION
Show room information (if available) on presentation page. Do not display "in" on speaker page or list of presentations if room information is not available for a presentation.