### PR TITLE
Disable use of caching in schedule templates.

### DIFF
--- a/conf_site/templates/symposion/schedule/schedule_conference.html
+++ b/conf_site/templates/symposion/schedule/schedule_conference.html
@@ -1,6 +1,6 @@
 {% extends "site_base.html" %}
 
-{% load cache flatblocks i18n %}
+{% load flatblocks i18n %}
 
 {% block head_title %}Conference Schedule{% endblock %}
 
@@ -17,12 +17,10 @@
     {% flatblock "schedule_top" %}
 
     {% for section in sections %}
-        {% cache 600 "schedule-table" section.schedule.section %}
             {% for timetable in section.days %}
                 <h3>{{ section.schedule.section.name }} — {{ timetable.day.date }}</h3>
                 {% include "symposion/schedule/_grid.html" %}
             {% endfor %}
-        {% endcache %}
     {% endfor %}
 
     {% flatblock "schedule_bottom" %}

--- a/conf_site/templates/symposion/schedule/schedule_detail.html
+++ b/conf_site/templates/symposion/schedule/schedule_detail.html
@@ -1,6 +1,6 @@
 {% extends "site_base.html" %}
 
-{% load cache flatblocks i18n sitetree %}
+{% load flatblocks i18n sitetree %}
 
 {% block head_title %}Conference Schedule{% endblock %}
 
@@ -16,12 +16,10 @@
     </div>
     {% flatblock "schedule_top" %}
 
-    {% cache 600 "schedule-table" schedule.section %}
         {% for timetable in days %}
             <h3>{{ timetable.day.date }}</h3>
             {% include "symposion/schedule/_grid.html" %}
         {% endfor %}
-    {% endcache %}
 
     {% flatblock "schedule_bottom" %}
 {% endblock %}

--- a/conf_site/templates/symposion/schedule/schedule_list.html
+++ b/conf_site/templates/symposion/schedule/schedule_list.html
@@ -1,7 +1,6 @@
 {% extends "site_base.html" %}
 
 {% load i18n %}
-{% load cache %}
 {% load sitetree %}
 
 {% block head_title %}Presentation Listing{% endblock %}
@@ -29,7 +28,6 @@
 
 {% block body %}
     <h2>Accepted {{ schedule.section.name }}</h2>
-    {% cache 600 "schedule-list" schedule.section.name %}
         {% for presentation in presentations %}
             <div class="row">
                 <div class="col-md-8 presentation well">
@@ -48,5 +46,4 @@
                 </div>
             </div>
         {% endfor %}
-    {% endcache %}
 {% endblock %}


### PR DESCRIPTION
Disable caching in schedule templates to ensure that changes to schedule
are reflected on the site immediately.