### PR TITLE
Modify how schedules are displayed.

### DIFF
--- a/conf_site/templates/symposion/schedule/_grid.html
+++ b/conf_site/templates/symposion/schedule/_grid.html
@@ -12,7 +12,7 @@
             <tr>
                 <td class="time">{{ row.time|date:"h:iA" }}</td>
                 {% for slot in row.slots %}
-                    <td class="slot slot-{{ slot.content.proposal.kind }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
+                    <td class="slot slot-{{ slot.content.proposal.kind.slug }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
                       {# this is a kludge until the slot.kind model has a property #}
                       {# to distinguish a presentation from a non-presentation slot #}
                         {% if slot.kind.label in "Track 5 Track 4 Track 3 Track 2 Track 1 Tutorial Track 5 Tutorial Track 4 Tutorial Track 3 Tutorial Track 2 Tutorial Track 1 Tutorials Track 1 Tutorials Track 2" %}

--- a/conf_site/templates/symposion/schedule/_grid.html
+++ b/conf_site/templates/symposion/schedule/_grid.html
@@ -13,24 +13,20 @@
                 <td class="time">{{ row.time|date:"h:iA" }}</td>
                 {% for slot in row.slots %}
                     <td class="slot slot-{{ slot.content.proposal.kind.slug }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
-                      {# this is a kludge until the slot.kind model has a property #}
-                      {# to distinguish a presentation from a non-presentation slot #}
-                        {% if slot.kind.label in "Track 5 Track 4 Track 3 Track 2 Track 1 Tutorial Track 5 Tutorial Track 4 Tutorial Track 3 Tutorial Track 2 Tutorial Track 1 Tutorials Track 1 Tutorials Track 2" %}
-                            {% if slot.content %}
-                                <span class="title">
-                                    <a href="{% url "schedule_presentation_detail" slot.content.pk %}">{{ slot.content.title }}</a>
-                                </span>
-                                <span class="speaker">
-                                    {{ slot.content.speakers|join:", " }}
-                                </span>
-                            {% endif %}
+                      {% if slot.content %}
+                          <span class="title">
+                              <a href="{% url "schedule_presentation_detail" slot.content.pk %}">{{ slot.content.title }}</a>
+                          </span>
+                          <span class="speaker">
+                              {{ slot.content.speakers|join:", " }}
+                          </span>
+                      {% else %}
+                        {% if slot.content_override_html %}
+                            {{ slot.content_override_html|safe }}
                         {% else %}
-                            {% if slot.content_override.raw %}
-                                {{ slot.content_override.rendered|safe }}
-                            {% else %}
-                                {{ slot.kind.label }}
-                            {% endif %}
+                            {{ slot.kind.label }}
                         {% endif %}
+                      {% endif %}
                     </td>
                 {% endfor %}
                 {% if forloop.last %}


### PR DESCRIPTION
  - Make sure that schedule table cell CSS classes use proposal kind slugs (and not proposal kind names, which might be capitalized).
  - Simplify display logic for schedule table cells to ensure that content overrides display correctly.