### PR TITLE
Add the standard ModelBackend for local development

### DIFF
--- a/conf_site/settings/local.example.py
+++ b/conf_site/settings/local.example.py
@@ -1,4 +1,8 @@
 from .dev import *  # noqa
 
+    
+AUTHENTICATION_BACKENDS += [
+  'django.contrib.auth.backends.'django.contrib.auth.backends.ModelBackend''
+]
 
 # Override settings here


### PR DESCRIPTION
In production the system uses the symposion auth backend, this doesn't seem necessary for local developing
