### PR TITLE
Remove hardcoded time formats from templates.

### DIFF
--- a/conf_site/templates/symposion/schedule/_edit_grid.html
+++ b/conf_site/templates/symposion/schedule/_edit_grid.html
@@ -10,7 +10,7 @@
     <tbody>
         {% for row in timetable %}
             <tr>
-                <td class="time">{{ row.time|date:"h:iA" }}</td>
+                <td class="time">{{ row.time }}</td>
                 {% for slot in row.slots %}
                     <td class="slot slot-{{ slot.kind.label }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
                       {# this is a kludge until the slot.kind model has a property #}

--- a/conf_site/templates/symposion/schedule/_grid.html
+++ b/conf_site/templates/symposion/schedule/_grid.html
@@ -10,7 +10,7 @@
     <tbody>
         {% for row in timetable %}
             <tr>
-                <td class="time">{{ row.time|date:"h:iA" }}</td>
+                <td class="time">{{ row.time }}</td>
                 {% for slot in row.slots %}
                     <td class="slot slot-{{ slot.content.proposal.kind.slug }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
                       {% if slot.content %}


### PR DESCRIPTION
Addendum to #101. Stop schedule grid templates from hardcoding 12 hour
time ("h:iA"). This will ensure that settings.TIME_FORMAT (which is
site-specific) will take precedence.