### PR TITLE
Add missing CSV file template.

### DIFF
--- a/conf_site/templates/symposion/schedule/schedule_list.csv
+++ b/conf_site/templates/symposion/schedule/schedule_list.csv
@@ -1,0 +1,3 @@
+"Presentation","Speakers","URL","Time","Room"
+{% for presentation in presentations %}"{{ presentation.title|addslashes }}","{{ presentation.speakers|join:' & '|addslashes }}","http://pydata.org{% url 'schedule_presentation_detail' presentation.pk %}","{{ presentation.slot.day.date|date:'l' }} {{ presentation.slot.start }}-{{ presentation.slot.end }}","{{ presentation.slot.rooms|join:' & '|addslashes }}"
+{% endfor %}


### PR DESCRIPTION
Add "schedule_list.csv" template used by symposion's `schedule_list_csv` view.