### PR TITLE
Api to show details about the conference

### DIFF
--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
 
 
@@ -9,3 +10,10 @@ class SpeakerSerializer(serializers.ModelSerializer):
     class Meta:
         model = Speaker
         fields = ('username', 'name', 'email')
+
+
+class ConferenceSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Conference
+        exclude = ('id', 'timezone')

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
+from symposion.schedule.models import Presentation, Slot
 
 
 class SpeakerSerializer(serializers.ModelSerializer):
@@ -17,3 +18,22 @@ class ConferenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Conference
         exclude = ('id', 'timezone')
+
+
+class SlotSerializer(serializers.ModelSerializer):
+    day = serializers.StringRelatedField()
+    kind = serializers.StringRelatedField()
+
+    class Meta:
+        model = Slot
+        exclude = ('id', 'content_override', 'content_override_html')
+
+
+class PresentationSerializer(serializers.ModelSerializer):
+    speaker = SpeakerSerializer()
+    slot = SlotSerializer()
+    section = serializers.StringRelatedField()
+
+    class Meta:
+        model = Presentation
+        exclude = ('id', 'description_html', 'abstract_html', 'proposal_base')

--- a/conf_site/api/urls.py
+++ b/conf_site/api/urls.py
@@ -7,6 +7,7 @@ from . import views
 # Create a router and register our viewsets with it.
 router = SimpleRouter()
 router.register(r'speaker', views.SpeakerViewSet)
+router.register(r'presentation', views.PresentationViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/conf_site/api/urls.py
+++ b/conf_site/api/urls.py
@@ -10,4 +10,5 @@ router.register(r'speaker', views.SpeakerViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^$', views.ConferenceDetail.as_view()),
 ]

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -1,9 +1,11 @@
 from rest_framework import viewsets
-from rest_framework import response
+from rest_framework import views
+from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
+from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker
 
-from .serializers import SpeakerSerializer
+from .serializers import SpeakerSerializer, ConferenceSerializer
 
 
 class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
@@ -18,3 +20,15 @@ class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
         user__isnull=False,
     )
     serializer_class = SpeakerSerializer
+
+
+class ConferenceDetail(views.APIView):
+    """
+    Returns details about the Conference object in the
+    Conference model.
+    """
+
+    def get(request, *args, **kwargs):
+        conference = Conference.objects.first()
+        serializer = ConferenceSerializer(conference)
+        return Response(serializer.data)

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -4,8 +4,9 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker
+from symposion.schedule.models import Presentation
 
-from .serializers import SpeakerSerializer, ConferenceSerializer
+from .serializers import SpeakerSerializer, PresentationSerializer
 
 
 class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
@@ -32,3 +33,13 @@ class ConferenceDetail(views.APIView):
         conference = Conference.objects.first()
         serializer = ConferenceSerializer(conference)
         return Response(serializer.data)
+
+
+class PresentationViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Returns a the list of all presentations within the conference.
+    Allows lookups through the `id` parameter.
+    """
+    permission_classes = (IsAdminUser,)
+    queryset = Presentation.objects.select_related('slot').all()
+    serializer_class = PresentationSerializer


### PR DESCRIPTION
@gvwilson @aterrel @martey 

For PyData Seattle, `api/conference` returns

```json
{
    "title": "PyData Seattle 2015",
    "start_date": "2015-07-24",
    "end_date": "2015-07-26"
}
```

This should be merged after #115 