### PR TITLE
Api to show Presentations and Sponsors

### DIFF
--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -1,6 +1,5 @@
-from django.core.urlresolvers import reverse_lazy
-
 from rest_framework import serializers
+from rest_framework.reverse import reverse_lazy
 
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
@@ -13,7 +12,11 @@ class SpeakerSerializer(serializers.ModelSerializer):
     absolute_url = serializers.SerializerMethodField()
 
     def get_absolute_url(self, obj):
-        return reverse_lazy('speaker_profile', kwargs={'pk': obj.pk})
+        return reverse_lazy(
+            'speaker_profile',
+            kwargs={'pk': obj.pk},
+            request=self.context['request'],
+        )
 
     class Meta:
         model = Speaker
@@ -48,7 +51,11 @@ class PresentationSerializer(serializers.ModelSerializer):
     absolute_url = serializers.SerializerMethodField()
 
     def get_absolute_url(self, obj):
-        return reverse_lazy('schedule_presentation_detail', args=[obj.pk])
+        return reverse_lazy(
+            'schedule_presentation_detail',
+            args=[obj.pk],
+            request=self.context['request'],
+        )
 
     class Meta:
         model = Presentation
@@ -64,7 +71,14 @@ class SponsorLevelSerializer(serializers.ModelSerializer):
 
 class SponsorSerializer(serializers.ModelSerializer):
     level = SponsorLevelSerializer()
-    absolute_url = serializers.URLField(source='get_absolute_url')
+    absolute_url = serializers.SerializerMethodField()
+
+    def get_absolute_url(self, obj):
+        return reverse_lazy(
+            'sponsor_detail',
+            kwargs={'pk': obj.pk},
+            request=self.context['request'],
+        )
 
     class Meta:
         model = Sponsor

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
 from symposion.schedule.models import Presentation, Slot
-from symposion.sponsorship.models import Sponsor
+from symposion.sponsorship.models import Sponsor, SponsorLevel
 
 
 class SpeakerSerializer(serializers.ModelSerializer):
@@ -55,8 +55,15 @@ class PresentationSerializer(serializers.ModelSerializer):
         exclude = ('id', 'description_html', 'abstract_html', 'proposal_base')
 
 
+class SponsorLevelSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = SponsorLevel
+        fields = ('name', 'cost')
+
+
 class SponsorSerializer(serializers.ModelSerializer):
-    level = serializers.SlugRelatedField(read_only=True, slug_field='name')
+    level = SponsorLevelSerializer()
     absolute_url = serializers.URLField(source='get_absolute_url')
 
     class Meta:

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -1,3 +1,5 @@
+from django.core.urlresolvers import reverse_lazy
+
 from rest_framework import serializers
 
 from symposion.speakers.models import Speaker, User
@@ -5,7 +7,17 @@ from symposion.speakers.models import Speaker, User
 
 class SpeakerSerializer(serializers.ModelSerializer):
     username = serializers.StringRelatedField(source='user')
+    absolute_url = serializers.SerializerMethodField()
+
+    def get_absolute_url(self, obj):
+        return reverse_lazy('speaker_profile', kwargs={'pk': obj.pk})
 
     class Meta:
         model = Speaker
-        fields = ('username', 'name', 'email')
+        fields = (
+            'username',
+            'name',
+            'email',
+            'absolute_url',
+        )
+

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
+from symposion.sponsorship.models import Sponsor
 
 
 class SpeakerSerializer(serializers.ModelSerializer):
@@ -29,3 +30,19 @@ class ConferenceSerializer(serializers.ModelSerializer):
         model = Conference
         exclude = ('id', 'timezone')
 
+
+class SponsorSerializer(serializers.ModelSerializer):
+    level = serializers.SlugRelatedField(read_only=True, slug_field='name')
+    absolute_url = serializers.URLField(source='get_absolute_url')
+
+    class Meta:
+        model = Sponsor
+        fields = (
+            'name',
+            'external_url',
+            'contact_name',
+            'contact_email',
+            'level',
+            'absolute_url',
+            'annotation',
+        )

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
+from symposion.schedule.models import Presentation, Slot
 from symposion.sponsorship.models import Sponsor
 
 
@@ -29,6 +30,29 @@ class ConferenceSerializer(serializers.ModelSerializer):
     class Meta:
         model = Conference
         exclude = ('id', 'timezone')
+
+
+class SlotSerializer(serializers.ModelSerializer):
+    day = serializers.StringRelatedField()
+    kind = serializers.StringRelatedField()
+
+    class Meta:
+        model = Slot
+        exclude = ('id', 'content_override', 'content_override_html')
+
+
+class PresentationSerializer(serializers.ModelSerializer):
+    speaker = SpeakerSerializer()
+    slot = SlotSerializer()
+    section = serializers.StringRelatedField()
+    absolute_url = serializers.SerializerMethodField()
+
+    def get_absolute_url(self, obj):
+        return reverse_lazy('schedule_presentation_detail', args=[obj.pk])
+
+    class Meta:
+        model = Presentation
+        exclude = ('id', 'description_html', 'abstract_html', 'proposal_base')
 
 
 class SponsorSerializer(serializers.ModelSerializer):

--- a/conf_site/api/serializers.py
+++ b/conf_site/api/serializers.py
@@ -2,6 +2,7 @@ from django.core.urlresolvers import reverse_lazy
 
 from rest_framework import serializers
 
+from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker, User
 
 
@@ -20,4 +21,11 @@ class SpeakerSerializer(serializers.ModelSerializer):
             'email',
             'absolute_url',
         )
+
+
+class ConferenceSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Conference
+        exclude = ('id', 'timezone')
 

--- a/conf_site/api/test/base.py
+++ b/conf_site/api/test/base.py
@@ -1,0 +1,18 @@
+import glob
+
+from django.contrib.auth.models import User
+from django.core.management import call_command
+
+from rest_framework.test import APITestCase
+
+
+class TestBase(APITestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.superuser = User.objects.create_superuser(
+            username='admin',
+            email='admin@pydata.org',
+            password='admin',
+        )
+        call_command('loaddata', *glob.glob('fixtures/*'))

--- a/conf_site/api/test/test_conference.py
+++ b/conf_site/api/test/test_conference.py
@@ -1,0 +1,17 @@
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+
+from .base import TestBase
+
+
+class TestConference(TestBase):
+
+    def test_conference_api_anonymous_user(self):
+        response = self.client.get(reverse('conference-detail'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {
+            'title': 'PyData',
+            'start_date': '2040-01-01',
+            'end_date': '2040-01-04',
+        })

--- a/conf_site/api/test/test_presentation.py
+++ b/conf_site/api/test/test_presentation.py
@@ -1,0 +1,83 @@
+import datetime
+
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+from symposion.schedule.models import (
+    Presentation,
+    Slot,
+    SlotKind,
+    Section,
+    Schedule,
+    Day,
+)
+from symposion.proposals.models import ProposalKind
+from symposion.speakers.models import Speaker, User
+
+from conf_site.proposals.models import Proposal
+
+from .base import TestBase
+
+
+class TestSponsor(TestBase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TestSponsor, cls).setUpTestData()
+        cls.speaker = Speaker.objects.create(
+            user=User.objects.create_user('test', 'test@pydata.org', 'test'),
+            name='test speaker',
+        )
+        cls.schedule = Schedule.objects.create(
+            section=Section.objects.first(),
+        )
+        cls.presentation = Presentation.objects.create(
+            slot=Slot.objects.create(
+                name='test slot',
+                day=Day.objects.create(
+                    schedule=cls.schedule,
+                    date=datetime.date.today(),
+                ),
+                kind=SlotKind.objects.create(
+                    schedule=cls.schedule,
+                    label='45-min talk',
+                ),
+                start=datetime.time(),
+                end=datetime.time(),
+            ),
+            title='test presentation',
+            description='test description',
+            abstract='test abstract',
+            speaker=cls.speaker,
+            proposal_base=Proposal.objects.create(
+                kind=ProposalKind.objects.first(),
+                title='Test proposal',
+                description='lorem ipsum'*15,
+                abstract='lorem ipsum'*15,
+                speaker=cls.speaker,
+                audience_level=Proposal.AUDIENCE_LEVEL_NOVICE,
+            ),
+            section=Section.objects.first(),
+        )
+
+    def test_presentation_list_api_anonymous_user(self):
+        response = self.client.get(reverse('presentation-list'))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_presentation_list_api_admin_user(self):
+        self.client.login(username='admin@pydata.org', password='admin')
+        response = self.client.get(reverse('presentation-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_presentation_detail_api_anonymous_user(self):
+        response = self.client.get(
+            reverse('presentation-detail',args=[self.presentation.pk])
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_presentation_detail_api_admin_user(self):
+        self.client.login(username='admin@pydata.org', password='admin')
+        response = self.client.get(
+            reverse('presentation-detail',args=[self.presentation.pk])
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/conf_site/api/test/test_speaker.py
+++ b/conf_site/api/test/test_speaker.py
@@ -1,0 +1,57 @@
+from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
+
+from rest_framework import status
+from symposion.speakers.models import Speaker
+
+from .base import TestBase
+
+
+class TestSpeaker(TestBase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TestSpeaker, cls).setUpTestData()
+        cls.speaker = Speaker.objects.create(
+            user=User.objects.create_user('test', 'test@pydata.org', 'test'),
+            name='test speaker',
+        )
+
+    def test_speaker_list_api_anonymous_user(self):
+        response = self.client.get(reverse('speaker-list'))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_speaker_list_api_speaker_user(self):
+        self.client.login(username='test@pydata.org', password='test')
+        response = self.client.get(reverse('speaker-list'))
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_speaker_list_api_admin_user(self):
+        self.client.login(username='admin@pydata.org', password='admin')
+        response = self.client.get(reverse('speaker-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(
+            {
+                'username': self.speaker.user.username,
+                'name': self.speaker.name,
+                'email': self.speaker.user.email,
+                'absolute_url': reverse('speaker_profile', args=[self.speaker.pk]),
+            },
+            response.data
+        )
+
+    def test_speaker_detail_api_admin_user(self):
+        self.client.login(username='admin@pydata.org', password='admin')
+        response = self.client.get(
+            reverse('speaker-detail', args=[self.speaker.pk])
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            {
+                'username': self.speaker.user.username,
+                'name': self.speaker.name,
+                'email': self.speaker.user.email,
+                'absolute_url': reverse('speaker_profile', args=[self.speaker.pk]),
+            },
+            response.data
+        )

--- a/conf_site/api/test/test_sponsor.py
+++ b/conf_site/api/test/test_sponsor.py
@@ -1,0 +1,48 @@
+from django.core.urlresolvers import reverse
+
+from rest_framework import status
+from symposion.sponsorship.models import Sponsor
+
+from .base import TestBase
+
+
+class TestSponsor(TestBase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super(TestSponsor, cls).setUpTestData()
+        cls.sponsor = Sponsor.objects.first()
+
+    def test_speaker_list_api_anonymous_user(self):
+        response = self.client.get(reverse('sponsor-list'))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(
+            {
+                'name': self.sponsor.name,
+                'external_url': self.sponsor.external_url,
+                'contact_name': self.sponsor.contact_name,
+                'contact_email': self.sponsor.contact_email,
+                'level': str(self.sponsor.level),
+                'absolute_url': self.sponsor.get_absolute_url(),
+                'annotation': self.sponsor.annotation,
+            },
+            response.data
+        )
+
+    def test_speaker_detail_api_anonymous_user(self):
+        response = self.client.get(
+            reverse('sponsor-detail',args=[self.sponsor.pk])
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            {
+                'name': self.sponsor.name,
+                'external_url': self.sponsor.external_url,
+                'contact_name': self.sponsor.contact_name,
+                'contact_email': self.sponsor.contact_email,
+                'level': str(self.sponsor.level),
+                'absolute_url': self.sponsor.get_absolute_url(),
+                'annotation': self.sponsor.annotation,
+            },
+            response.data
+        )

--- a/conf_site/api/urls.py
+++ b/conf_site/api/urls.py
@@ -7,6 +7,7 @@ from . import views
 # Create a router and register our viewsets with it.
 router = SimpleRouter()
 router.register(r'speaker', views.SpeakerViewSet)
+router.register(r'presentation', views.PresentationViewSet)
 router.register(r'sponsor', views.SponsorViewSet)
 
 urlpatterns = [

--- a/conf_site/api/urls.py
+++ b/conf_site/api/urls.py
@@ -7,6 +7,7 @@ from . import views
 # Create a router and register our viewsets with it.
 router = SimpleRouter()
 router.register(r'speaker', views.SpeakerViewSet)
+router.register(r'sponsor', views.SponsorViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),

--- a/conf_site/api/urls.py
+++ b/conf_site/api/urls.py
@@ -10,4 +10,5 @@ router.register(r'speaker', views.SpeakerViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^$', views.ConferenceDetail.as_view(), name='conference-detail'),
 ]

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -1,9 +1,14 @@
 from rest_framework import viewsets
-from rest_framework import response
+from rest_framework import views
+from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
+from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker
 
-from .serializers import SpeakerSerializer
+from .serializers import (
+    ConferenceSerializer,
+    SpeakerSerializer,
+)
 
 
 class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
@@ -18,3 +23,16 @@ class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
         user__isnull=False,
     )
     serializer_class = SpeakerSerializer
+
+
+class ConferenceDetail(views.APIView):
+    """
+    Returns details about the Conference object in the
+    Conference model.
+    """
+
+    def get(request, *args, **kwargs):
+        conference = Conference.objects.first()
+        serializer = ConferenceSerializer(conference)
+        return Response(serializer.data)
+

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -15,7 +15,14 @@ from .serializers import (
 )
 
 
-class SpeakerViewSet(viewsets.ReadOnlyModelViewSet):
+class BaseViewSet(viewsets.ReadOnlyModelViewSet):
+
+    def get_serializer_context(self):
+        '''Pass request variable to obtain absolute URLs.'''
+        return {'request': self.request}
+
+
+class SpeakerViewSet(BaseViewSet):
     """
     Returns a the list of all speaker profiles.
     Allows lookups through the `id` parameter.
@@ -41,7 +48,7 @@ class ConferenceDetail(views.APIView):
         return Response(serializer.data)
 
 
-class PresentationViewSet(viewsets.ReadOnlyModelViewSet):
+class PresentationViewSet(BaseViewSet):
     """
     Returns a the list of all presentations within the conference.
     Allows lookups through the `id` parameter.
@@ -51,7 +58,7 @@ class PresentationViewSet(viewsets.ReadOnlyModelViewSet):
     serializer_class = PresentationSerializer
 
 
-class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
+class SponsorViewSet(BaseViewSet):
     """
     Returns a the list of all sponsors for the conference.
     Allows lookups through the `id` parameter.

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -4,11 +4,13 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker
+from symposion.schedule.models import Presentation
 from symposion.sponsorship.models import Sponsor
 
 from .serializers import (
     ConferenceSerializer,
     SpeakerSerializer,
+    PresentationSerializer,
     SponsorSerializer,
 )
 
@@ -37,6 +39,16 @@ class ConferenceDetail(views.APIView):
         conference = Conference.objects.first()
         serializer = ConferenceSerializer(conference)
         return Response(serializer.data)
+
+
+class PresentationViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Returns a the list of all presentations within the conference.
+    Allows lookups through the `id` parameter.
+    """
+    permission_classes = (IsAdminUser,)
+    queryset = Presentation.objects.select_related('slot').all()
+    serializer_class = PresentationSerializer
 
 
 class SponsorViewSet(viewsets.ReadOnlyModelViewSet):

--- a/conf_site/api/views.py
+++ b/conf_site/api/views.py
@@ -4,10 +4,12 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
 from symposion.conference.models import Conference
 from symposion.speakers.models import Speaker
+from symposion.sponsorship.models import Sponsor
 
 from .serializers import (
     ConferenceSerializer,
     SpeakerSerializer,
+    SponsorSerializer,
 )
 
 
@@ -36,3 +38,11 @@ class ConferenceDetail(views.APIView):
         serializer = ConferenceSerializer(conference)
         return Response(serializer.data)
 
+
+class SponsorViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Returns a the list of all sponsors for the conference.
+    Allows lookups through the `id` parameter.
+    """
+    queryset = Sponsor.objects.defer('annotation').all()
+    serializer_class = SponsorSerializer

--- a/conf_site/templates/symposion/sponsorship/list.html
+++ b/conf_site/templates/symposion/sponsorship/list.html
@@ -23,8 +23,14 @@
                             </a>
                         {% endif %}
                     </div>
-                        <div class="col-md-9">
-                        <h5>{{ sponsor.name }}</h5>
+                    <div class="col-md-9">
+                        {% if request.user.is_superuser %}
+                            <a href="{% url 'sponsor_detail' sponsor.pk %}" title="Edit {{ sponsor.name }}">
+                                <h5>{{ sponsor.name }}</h5>
+                            </a>
+                        {% else %}
+                            <h5>{{ sponsor.name }}</h5>
+                        {% endif %}
                         <p><a href="{{ sponsor.external_url }}">{{ sponsor.external_url }}</a></p>
                         <p>{{ sponsor.listing_text|markdown }}</p>
                     </div>


### PR DESCRIPTION
Exposes Sponsors at the `/api/sponsor` endpoint.

The response would look like:
```py
    {
        "name": "Continuum Analytics",
        "external_url": "http://continuum.io/",
        "level": "PyData Founding",
        "annotation": "Continuum Analytics develops Anaconda, the leading modern open source analytics platform powered by Python. Continuum’s Python-based platform and consulting services empower organizations to analyze, manage and visualize big data - turning massive datasets into actionable insights and business value. Built on proven open-source technology and easily integrated within existing IT environments, Anaconda allows organizations to make critical business decisions based on their data quickly, easily, inexpensively, and with flexibility. Without having to worry about how to access their data, organizations can free up resources to solve actual problems. Continuum’s founders and developers have created or contribute to some of the most popular data science technologies, including NumPy, SciPy, Pandas, IPython, and many others. To learn more about the Anaconda platform, training and consulting services, visit continuum.io."
    }
```
@gvwilson: There is a slight problem here. There is no such view that shows the details of a particular sponsor. There only exists views to list all the sponsors at a url (see http://pydata.org/paris2016/sponsors/).
So currently a PyData admin cannot import a Sponsor by giving its unique URL.

There are two solutions to it:
- Import all Sponsors at once. This would however not allow admins to edit fields before saving them. Also, we cannot build a functionality to update a Sponsor instance.
- PyData maintains a fork of symposion at [pydata/symposion](https://github.com/pydata/symposion). We can add a detail view to give each sponsor a unique view.
@martey Is that feasible and acceptable?

