### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ PyData Symposion
 This repository contains code for the PyData Seattle 2015 site.
 The Sphinx docs_ have instructions for using and working on the site.
 
-.. _docs: http://pydata-conference-management.readthedocs.org/en/latest/index.html
+.. _docs: https://pydata-conference-management.readthedocs.io/en/latest/index.html
 
 If you are experiencing problems with the site, please open an issue_ or 
 e-mail <web@pydata.org>.

--- a/docs/source/management.rst
+++ b/docs/source/management.rst
@@ -7,7 +7,7 @@ use more docs for the perspective of conference organizers.
 
 This page is a start.
 
-.. _Symposion: http://symposion.readthedocs.org/en/latest/index.html
+.. _Symposion: https://symposion.readthedocs.io/en/latest/index.html
 
 Content Management
 ------------------
@@ -98,7 +98,7 @@ you view the tree and see url patterns such as *cms_page "cfp/"*.
 The django-sitetree_ app documents discuss in depth how to use the admin for
 editing sitetree pages.
 
-.. _django-sitetree: http://django-sitetree.readthedocs.org/en/latest/
+.. _django-sitetree: https://django-sitetree.readthedocs.io/en/latest/
 
 .. Warning:: 
     The django admin might not show changes immediately on refresh.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.