### PR TITLE
Software updates.

### DIFF
--- a/conf_site/apps.py
+++ b/conf_site/apps.py
@@ -1,5 +1,6 @@
+from importlib import import_module
+
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.importlib import import_module
 
 
 class AppConfig(BaseAppConfig):

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -144,7 +144,6 @@ INSTALLED_APPS = [
     # external
     "account",
     "analytical",
-    "django_extensions",
     "django_markdown",
     "easy_thumbnails",
     "flatblocks",

--- a/conf_site/speakers/views.py
+++ b/conf_site/speakers/views.py
@@ -1,9 +1,9 @@
 import os
 from tempfile import mkstemp
+from wsgiref.util import FileWrapper
 
 import unicodecsv
 
-from django.core.servers.basehttp import FileWrapper
 from django.http import HttpResponse
 from django.views.generic import View
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.8.15
+Django==1.9.12
 django-analytical==2.2.1
 django-extensions==1.5.1
 django-flatblocks==0.9.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,6 @@
 Django==1.9.12
 django-analytical==2.2.1
+django-appconf>=1.0.2,<2.0
 django-flatblocks==0.9.2
 django-jsonfield==0.9.13
 django-markdown==0.8.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,5 @@
 Django==1.9.12
 django-analytical==2.2.1
-django-extensions==1.5.1
 django-flatblocks==0.9.2
 django-jsonfield==0.9.13
 django-markdown==0.8.4


### PR DESCRIPTION
Upgrade to Django 1.9 and make some of the requisite software updates and changes necessary to get the conf_site code working with a patched version of symposion master.

Note that **this pull request temporarily breaks the public-facing parts of the website**, because the current version of pinax-theme-bootstrap used is not compatible with Django 1.9. We could upgrade, but since the entire package is going to be removed as a result of upcoming theme changes, this wouldn't be productive. The design changes are large and complicated enough that they deserve their own pull request.