### PR TITLE
Pin symposion checkout to specific commit.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,4 +19,4 @@ wagtail==1.8
 wagtailmenus==2.1.2
 virtualenv==15.0.3
 
-git+git://github.com/pydata/symposion.git@patched#egg=symposion
+git+git://github.com/pydata/symposion.git@6653f0190afb4cc5e984e29#egg=symposion


### PR DESCRIPTION
Pin our version of symposion to a specific commit instead of the patched
branch. This makes it easier to update conference sites with newer
versions (since the virtualenv creation portion of deployment relies on
Git commit hashes to determine whether a new virtualenv needs to be
created, a update to the patched branch will not cause symposion on
conference sites to be updated if there is no corresponding change in
the conf_site repository).