### PR TITLE
Upgrade pip and setuptools.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ fabtools==0.19.0
 gunicorn==19.6.0
 Pillow==3.3.1
 pinax-eventlog==1.1.2
-pip==8.1.2
+pip==9.0.1
 psycopg2==2.6.2
 pytz==2016.6.1
 unicodecsv==0.14.1


### PR DESCRIPTION
I think that the recent deployment errors are the result of using an old
version of pip and the changes introduced in setuptools 34
(https://github.com/pypa/setuptools/blob/master/CHANGES.rst#v3400).

Since these errors only occur when deploying to production conference
sites and not when deployment to local development environments, I
can't be certain that this commit actually fixes the issue.