### PR TITLE
Ensure up-to-date pip from virtualenv is used by Ansible.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ env: >
     DJANGO_SETTINGS_MODULE="conf_site.settings.travis-ci"
 before_install:
     - psql -c 'create database travis;' -U postgres
+    - "pip install --upgrade pip"
 install:
     - "pip install -r requirements/travis-ci.txt"
 script:

--- a/ansible/roles/web/tasks/django.yml
+++ b/ansible/roles/web/tasks/django.yml
@@ -57,9 +57,14 @@
         path={{ virtualenv_root }}/current
         src={{ virtualenv_root }}/{{ git_status.stdout }}
 
+- name: install latest version of pip
+  shell: "{{ virtualenv_root }}/current/bin/pip install --upgrade pip"
+
 - name: update virtualenv with requirements
-  pip: requirements={{ project_root }}/requirements/{{ environment_type }}.txt
-       virtualenv={{ virtualenv_root }}/current
+  shell: >
+    "{{ virtualenv_root }}/current/bin/pip"
+    install -r {{ project_root }}/requirements/{{ environment_type }}.txt
+    --upgrade
   notify: restart gunicorn
 
 - name: add supervisor configuration file for gunicorn

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,8 +14,6 @@ pinax-eventlog==1.1.2
 pip==9.0.1
 psycopg2==2.6.2
 pytz==2016.6.1
-setuptools==34.0.2
-six==1.10.0
 unicodecsv==0.14.1
 wagtail==1.8
 wagtailmenus==2.1.2


### PR DESCRIPTION
Using an old version of pip results in an error when installing packages (see https://github.com/pypa/setuptools/issues/937). These commits ensure that the installation happens with the most up-to-date version of pip available.