### PR TITLE
Fix multiple issues relating to sponsors.

### DIFF
--- a/conf_site/templates/homepage.html
+++ b/conf_site/templates/homepage.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags wagtailimages_tags %}
+{% load sponsorship_tags wagtailcore_tags wagtailimages_tags %}
 {% block body %}
 <div id="sli" class="text-center">
     <div class="bg-xc col-xs-12" data-stellar-background-ratio="1.1" data-stellar-vertical-offset="50"
@@ -37,6 +37,31 @@
             <div class="sec-ov-2">
                 {{ page.pydata_info_section }}
             </div>
+        </div>
+    </div>
+</section>
+<section>
+    <div class="container sp-logo-cs" style="background-color: #fff; display:table; padding-bottom:60px; position:relative;">
+        <h2 style="text-transform:uppercase">Our Sponsors</h2>
+        <div class="row text-center">
+            {% sponsor_levels as levels %}
+            {% for level in levels %}
+                {% if level.sponsors %}
+                    {% for sponsor in level.sponsors %}
+                        {# We don't display sponsors without logos. #}
+                        {% if sponsor.website_logo %}
+                        <div class="col-md-3 col-sm-4 col-xs-12 sp">
+                            <a href="{{ sponsor.external_url }}">
+                                <img src="{{ sponsor.website_logo.url }}" alt="{{ sponsor.name }}">
+                            </a>
+                        </div>
+                        {% endif %}
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </div>
+        <div class="row" style="margin: 0 33%;">
+            <a href="{% url 'sponsor_apply' %}" class="btn btn3">Become a Sponsor</a>
         </div>
     </div>
 </section>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,4 +19,4 @@ wagtail==1.8
 wagtailmenus==2.1.2
 virtualenv==15.1.0
 
-git+git://github.com/pydata/symposion.git@983ec0045f34f480059e5b2#egg=symposion
+git+git://github.com/pydata/symposion.git@d664b2bdfb901029937b7f8#egg=symposion


### PR DESCRIPTION
  - Use a version of symposion where the site won't crash if a sponsor does not have an uploaded logo and the sponsors page is accessed.
  - Add sponsor logos to new section on homepage.