### PR TITLE
Use CF-Visitor header to redirect HTTP requests.

### DIFF
--- a/ansible/roles/web/templates/nginx-site.conf
+++ b/ansible/roles/web/templates/nginx-site.conf
@@ -9,6 +9,14 @@ server {
     real_ip_header CF-Connecting-IP;
     real_ip_recursive on;
 
+    {% if environment_type != "dev" %}
+    # We can't just redirect all HTTP requests to HTTPS, since the upstream
+    # request will be using HTTP. We have to check CloudFlare's CF-Visitor
+    # header.
+    if ($http_cf_visitor ~ '{"scheme":"http"}') {
+        return 301 https://{{ website_domain }}{{ subdirectory }}$request_uri;
+    }
+    {% endif %}
 
     access_log {{ project_root }}/logs/nginx-access.log;
     error_log {{ project_root }}/logs/nginx-error.log;


### PR DESCRIPTION
Use CloudFlare's CF-Visitor header to redirect HTTP requests to HTTPS when not using local development environment.