### PR TITLE
Change speaker profile link in footer.

### DIFF
--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -153,12 +153,12 @@
                 <h4>ACCOUNT</h4>
                 {% if request.user.is_authenticated %}
                 <ul>
-                    {% if request.user.speaker_profile %}
-                    <li><a href="{% url 'speaker_profile' request.user.speaker_profile.pk %}">Speaker Profile</a></li>
-                    {% endif %}
                     <li><a href="{% url 'dashboard' %}">{% trans "Dashboard" %}</a></li>
                     {% if request.user.is_staff %}
                     <li><a href="{% url THEME_ADMIN_URL|default:'admin:index' %}">{% trans 'Admin' %}</a></li>
+                    {% endif %}
+                    {% if request.user.speaker_profile %}
+                    <li><a href="{% url 'speaker_edit' %}">Speaker Profile</a></li>
                     {% endif %}
                     <li><a href="{% url 'account_logout' %}">{% trans "Log out" %}</a>
                 </ul>


### PR DESCRIPTION
Since the speaker profile page is only available if the speaker has accepted presentations, it does not make sense to link to it in the footer (since all non-staff users will receive a 404 until proposals are
reviewed).

Change link to speaker profile edit page. Move link below links to dashboard and admin, since it is arguably less important.