### PR TITLE
Remove "versions" panel from django-debug-toolbar.

### DIFF
--- a/conf_site/settings/dev.py
+++ b/conf_site/settings/dev.py
@@ -14,6 +14,19 @@ DATABASES = {
     "default": DATABASES_DEFAULT,                   # noqa: F405
 }
 
+DEBUG_TOOLBAR_PANELS = [
+    "debug_toolbar.panels.timer.TimerPanel",
+    "debug_toolbar.panels.settings.SettingsPanel",
+    "debug_toolbar.panels.headers.HeadersPanel",
+    "debug_toolbar.panels.request.RequestPanel",
+    "debug_toolbar.panels.sql.SQLPanel",
+    "debug_toolbar.panels.staticfiles.StaticFilesPanel",
+    "debug_toolbar.panels.templates.TemplatesPanel",
+    "debug_toolbar.panels.cache.CachePanel",
+    "debug_toolbar.panels.signals.SignalsPanel",
+    "debug_toolbar.panels.logging.LoggingPanel",
+    "debug_toolbar.panels.redirects.RedirectsPanel",
+]
 MIDDLEWARE_CLASSES = [
     "debug_toolbar.middleware.DebugToolbarMiddleware",
     ] + MIDDLEWARE_CLASSES                          # noqa: F405


### PR DESCRIPTION
The "Versions" panel of django-debug-toolbar is not compatible with wagtailmenus (see https://github.com/jazzband/django-debug-toolbar/issues/922 and https://github.com/rkhleics/wagtailmenus/issues/115).