### PR TITLE
Comment out parallax scrolling to avoid bug.

### DIFF
--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -183,6 +183,7 @@
 <script src="{{ STATIC_URL }}js/retina.min.js"></script>
 <script src="{{ STATIC_URL }}js/jquery.sticky.js"></script>
 <script src="{{ STATIC_URL }}js/jquery.stellar.js"></script>
+<!--
 <script>
     jQuery(function($) {
         $(window).stellar();
@@ -197,6 +198,7 @@
          }
     });
 </script>
+-->
 {% block extra_script %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Workaround bug where long dropdown menus do not work because they appear beneath the homepage logo overlay image by removing stellar.js and all parallax scrolling.

This is a temporary fix - if I can find a way that the dropdown menus and parallax scrolling can both work, I will make further changes.