### PR TITLE
Remove missing static file references.

### DIFF
--- a/conf_site/templates/symposion/proposals/proposal_detail.html
+++ b/conf_site/templates/symposion/proposals/proposal_detail.html
@@ -105,22 +105,3 @@
 </div>
 </div>
 {% endblock %}
-
-{% block extra_script %}
-    <script src="{% static 'symposion/js/jquery.history.js' %}"></script>
-    <script type="text/javascript">
-        $(function() {
-            var History = window.History;
-
-            $(window).bind("anchorchange", function() {
-                $(".nav-tabs a[href='" + location.hash + "']").click();
-            });
-
-            $('#.nav-tabs a[data-toggle="tab"]').on('shown', function (e) {
-                if (History.enabled) {
-                    History.pushState(null, null, $(e.target).attr("href"));
-                }
-            });
-        });
-    </script>
-{% endblock extra_script %}

--- a/conf_site/templates/symposion/reviews/review_detail.html
+++ b/conf_site/templates/symposion/reviews/review_detail.html
@@ -179,23 +179,3 @@
     </div>
 </div>
 {% endblock %}
-
-{% block extra_script %}
-    <script src="{% static 'symposion/js/jquery.history.js' %}"></script>
-    <script type="text/javascript">
-        $(function() {
-            var History = window.History;
-
-            $(window).bind("anchorchange", function() {
-                $(".nav-tabs a[href='" + location.hash + "']").click();
-            });
-
-            $('#.nav-tabs a[data-toggle="tab"]').on('shown', function (e) {
-                if (History.enabled) {
-                    History.pushState(null, null, $(e.target).attr("href"));
-                }
-            });
-        });
-    </script>
-
-{% endblock %}

--- a/conf_site/templates/symposion/schedule/schedule_edit.html
+++ b/conf_site/templates/symposion/schedule/schedule_edit.html
@@ -10,10 +10,6 @@
 {% block right %}
 {% endblock %}
 
-{% block extra_head %}
-    <link rel="stylesheet" href="{% static 'chosen/chosen.css' %}"/>
-{% endblock %}
-
 {% block body %}
 <div class="container">
     <h1>Schedule Edit</h1>
@@ -32,12 +28,10 @@
 {% endblock %}
 
 {% block extra_script %}
-    <script src="{% static 'chosen/chosen.jquery.min.js' %}" type="text/javascript"></script>
     <script type="text/javascript">
         $(function() {
             $("a.edit-slot").click(function(e) {
                 $("#slotEditModal").load($(this).data("action"), function() {
-                    $("#id_presentation").chosen();
                     $("#slotEditModal").modal("show");
                 });
                 e.preventDefault();


### PR DESCRIPTION
Remove references to static files that are not a part of this codebase or symposion, since they cause ValueErrors with ManifestStaticFilesStorage.

  - chosen.js was removed from symposion some time ago (0fa4801941c41).
  - As far as I could find, jquery.history.js does not ever seem to have been included in symposion, despite being referenced as such in the pinax-project-symposion proposal_detail template that our template is based on. Since it doesn't look like the related code block was ever active and jquery.history.js (now https://github.com/browserstate/history.js) is unmaintained, and it doesn't look like the related code block was ever active, it makes significantly more sense to just remove it.

Note that this "missing files cause ManifestStaticFilesStorage to catch on fire at runtime" behavior can be turned off after we upgrade to Django 1.11 (see https://docs.djangoproject.com/en/1.11/releases/1.11/#django-contrib-staticfiles).