### PR TITLE
Improvements in email handling.

### DIFF
--- a/ansible/roles/web/templates/sensitive-settings.py
+++ b/ansible/roles/web/templates/sensitive-settings.py
@@ -15,7 +15,6 @@ SESSION_COOKIE_PATH = "{{ subdirectory }}" or "/"
 TIME_FORMAT = "{{ time_format }}"
 TIME_ZONE = "{{ timezone }}"
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_USE_TLS = True
 EMAIL_HOST = '{{ email_host_name }}'
 EMAIL_HOST_USER = 'noreply@pydata.org'

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -228,6 +228,7 @@ LOGGING = {
 ADMINS = (
     ('Admins', 'web@pydata.org'),
 )
+MANAGERS = [("PyData Admin", "admin@pydata.org"), ]
 
 DEFAULT_FROM_EMAIL = 'noreply@conf.pydata.org'
 

--- a/conf_site/settings/production.py
+++ b/conf_site/settings/production.py
@@ -13,4 +13,5 @@ DATABASES = {
 
 SITE_ID = 1
 
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
 - Use "console" email backend in local development.
 - Set `MANAGERS` settings so that sending email after a sponsor applies will work properly.