### PR TITLE
Create custom error page for CSRF errors.

### DIFF
--- a/conf_site/cms/tests/test_csrf_failure.py
+++ b/conf_site/cms/tests/test_csrf_failure.py
@@ -1,0 +1,10 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+
+class CsrfFailureTestCase(TestCase):
+    def test_access_csrf_failure_view(self):
+        """Verify that custom CSRF failure view loads properly."""
+        response = self.client.get(reverse("403-csrf"))
+        self.assertEqual(response.status_code, 403)
+        self.assertTemplateUsed(response, "403_csrf.html")

--- a/conf_site/cms/views.py
+++ b/conf_site/cms/views.py
@@ -1,5 +1,21 @@
+from django.template.response import TemplateResponse
+
 from account.forms import LoginEmailForm
 from account.views import LoginView
+
+
+def csrf_failure(request, reason=""):
+    """
+    Custom view for users who encounter CSRF errors.
+
+    https://docs.djangoproject.com/en/1.9/ref/settings/#csrf-failure-view
+
+    When we upgrade to Django 1.10, this view can be removed.
+
+    """
+    response = TemplateResponse(
+        request=request, template="403_csrf.html", status=403)
+    return response
 
 
 class LoginEmailView(LoginView):

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -264,6 +264,7 @@ CACHES = {
     }
 }
 CONFERENCE_ID = 1
+CSRF_FAILURE_VIEW = "conf_site.cms.views.csrf_failure"
 SESSION_ENGINE = "django.contrib.sessions.backends.cached_db"
 STATICFILES_STORAGE = (
     "django.contrib.staticfiles.storage.ManifestStaticFilesStorage")

--- a/conf_site/settings/travis-ci.py
+++ b/conf_site/settings/travis-ci.py
@@ -13,6 +13,7 @@ DATABASES = {
         "PORT": "", }
 }
 
+GOOGLE_ANALYTICS_PROPERTY_ID = "UA-000000-0"
 SECRET_KEY = "foobar"
 STATICFILES_STORAGE = (
     "django.contrib.staticfiles.storage.StaticFilesStorage")

--- a/conf_site/templates/403_csrf.html
+++ b/conf_site/templates/403_csrf.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}CSRF Error{% endblock %}
+
+{% block body %}
+<div class="container news-xl">
+    <h1>CSRF Security Token is Missing or Incorrect</h1>
+    <p>The site could not find a required security token. Please try:</p>
+    <ul>
+        <li>clearing all pydata.org cookies</li>
+        <li>reloading the previous page and re-entering your data</li>
+    </ul>
+    <p>
+        If neither of these steps work, please
+        <a href="mailto:admin@pydata.org">contact PyData</a> directly.
+    </p>
+{% endblock %}

--- a/conf_site/urls.py
+++ b/conf_site/urls.py
@@ -15,7 +15,7 @@ from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 
-from cms.views import LoginEmailView
+from cms.views import csrf_failure, LoginEmailView
 from speakers.views import ExportAcceptedSpeakerEmailView
 
 
@@ -44,6 +44,7 @@ urlpatterns += [
     url(r"^reviews/", include("symposion.reviews.urls")),
     url(r"^schedule/", include("symposion.schedule.urls")),
     url(r"^markitup/", include("markitup.urls")),
+    url(r"^403-csrf/", csrf_failure, name="403-csrf"),
     url(r"^413/", TemplateView.as_view(template_name="413.html")),
     url(r"", include(wagtail_urls)),
 ]


### PR DESCRIPTION
Create custom template, view, and automated tests for a custom error page for users that might encounter CSRF errors when submitting forms on conference sites.