### PR TITLE
Documentation errata fixes.

### DIFF
--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -107,7 +107,7 @@ Required variables include:
 Deploying
 ~~~~~~~~~
 
-Deployment occurs by running the `ansible-playbook` command.
+Deployment occurs by running the `ansible-playbook` command::
 
     ansible-playbook -i ansible/hosts --ask-vault ansible/production.yml -l gotham2017,metropolis2017
 

--- a/docs/source/deployment.rst
+++ b/docs/source/deployment.rst
@@ -146,7 +146,7 @@ steps are only necessary for PyData conference sites, and are marked as such.
     ssh <conference site IP address>
     cd /srv/pydata
     source ~/.virtualenvs/current/bin/activate
-    ./manage loaddata fixtures/*
+    DJANGO_SETTINGS_MODULE="conf_site.settings.production" ./manage loaddata fixtures/*
 
   At some point in the future, these fixtures might be converted to
   database migrations, making this step unnecessary.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ Contents:
    development
    deployment
    management
+   schedule-creation
 
 
 

--- a/docs/source/schedule-creation.rst
+++ b/docs/source/schedule-creation.rst
@@ -1,0 +1,39 @@
+Schedule Creation
+=================
+
+This documentation is incomplete.
+
+Creating a Schedule object
+--------------------------
+
+The first part of the schedule that needs to be created is the `Schedule`
+object.
+
+  - One `Schedule` should be created per session. For an example of this, see
+    the `London 2016 schedule`_ (which consists of one day of tutorial sessions,
+    and two days of general sessions).
+  - The "Published" checkbox should be unchecked. Otherwise, the schedule
+    will appear to be the public while it is being created.
+  - Make sure that the dates in this object correspond with the dates of the
+    schedule.
+  - For readability, the names of `slot kinds` should not correspond to room
+    names. If a presentation does not appear in a slot on the schedule, the
+    name of the slot kind will appear by default.
+
+.. _London 2016 schedule: https://pydata.org/london2016/schedule/
+
+Creating Rooms
+--------------
+
+The name of the room will appear on the schedule at the top of each column.
+
+
+Adding Presentations
+--------------------
+
+*to be written*
+
+Adding Plenary Slots
+++++++++++++++++++++
+
+*to be written*


### PR DESCRIPTION
Fix errors in deployment documentation that should have been committed back in March. Add beginnings of documentation on how to create conference schedules.