### PR TITLE
Add "body_outer" tag to base template. Fix #180.

### DIFF
--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -76,7 +76,9 @@
         </div>
     </div>
 </header>
-{% block body %}
+{% block body_outer %}
+    {% block body %}
+    {% endblock %}
 {% endblock %}
 {% if mailchimp_list_id %}
 <section>


### PR DESCRIPTION
Improve compatibility with old Symposion review templates by adding a "body_outer" block template tag to the base template. This block name is only used in the reviewing pages to generate a left-hand sidebar containing navigation links.