### PR TITLE
Don't display slot kinds in empty schedule slots.

### DIFF
--- a/conf_site/templates/symposion/schedule/_grid.html
+++ b/conf_site/templates/symposion/schedule/_grid.html
@@ -23,8 +23,6 @@
                       {% else %}
                         {% if slot.content_override_html %}
                             {{ slot.content_override_html|safe }}
-                        {% else %}
-                            {{ slot.kind.label }}
                         {% endif %}
                       {% endif %}
                     </td>


### PR DESCRIPTION
Make empty schedule slots display nothing if they are not attached to a presentation instead of displaying the slot kind name.