### PR TITLE
Add homepage info context processor.

### DIFF
--- a/conf_site/cms/context_processors.py
+++ b/conf_site/cms/context_processors.py
@@ -1,0 +1,28 @@
+from conf_site.cms.models import HomePage
+
+
+def homepage_context(request):
+    """
+    Add homepage information into context.
+
+    Add certain homepage fields into the general context so that they
+    are available from all pages, regardless of whether they were
+    generated with Wagtail or Symposion.
+    """
+    context = {}
+    # Assume that the homepage is the root page in Wagtail.
+    home_page = request.site.root_page.specific
+
+    if home_page.seo_title:
+        context["conference_title"] = home_page.seo_title
+    else:
+        context["conference_title"] = home_page.title
+    # If the homepage is not a HomePage (see models.py), it
+    # won't have any of these custom fields.
+    if type(home_page) == HomePage:
+        context["mailchimp_list_id"] = home_page.mailchimp_list_id
+        context["ticketing_url"] = home_page.ticketing_url
+        context["footer_email"] = home_page.footer_email
+        context["footer_twitter"] = home_page.footer_twitter
+
+    return context

--- a/conf_site/cms/models.py
+++ b/conf_site/cms/models.py
@@ -11,17 +11,11 @@ class HTMLBlock(StreamBlock):
     rich_text = RichTextBlock()
 
 
+# This class previously had a custom get_context method. It has
+# been retained to make future customizations easier.
 class CustomPage(Page):
     class Meta:
         abstract = True
-
-    def get_context(self, request):
-        """Pull additional context from homepage."""
-        context = super(CustomPage, self).get_context(request)
-        home_page = context['request'].site.root_page.specific
-        context["mailchimp_list_id"] = home_page.mailchimp_list_id
-        context["ticketing_url"] = home_page.ticketing_url
-        return context
 
 
 class HTMLPage(CustomPage):

--- a/conf_site/cms/tests/test_homepage_context.py
+++ b/conf_site/cms/tests/test_homepage_context.py
@@ -1,0 +1,48 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from symposion.conference.models import Conference
+from wagtail.wagtailcore.models import Site
+
+from conf_site.cms.models import HTMLPage, HomePage
+
+
+class HomePageContextTestCase(TestCase):
+    EXAMPLE_URL = "http://example.com"
+
+    @classmethod
+    def setUp(self):
+        """Create Wagtail pages used in tests."""
+        # The site needs a Conference to work properly.
+        self.conference = Conference(title="Conference")
+        self.conference.save()
+
+        homepage = HomePage(title="Home",
+                            path="0002",
+                            depth=1,
+                            ticketing_url=self.EXAMPLE_URL)
+        homepage.save()
+        # We need to replace the "Welcome to Wagtail" page with this page.
+        site = Site.objects.get()
+        site.root_page = homepage
+        site.save()
+
+        other_page = HTMLPage(title="Other",
+                              path="0003")
+        homepage.add_child(instance=other_page)
+        other_page.save()
+
+    def test_homepage_context(self):
+        homepage = HomePage.objects.get()
+        with self.settings(CONFERENCE_ID=self.conference.id):
+            response = self.client.get(homepage.url)
+        self.assertEqual(response.context["ticketing_url"], self.EXAMPLE_URL)
+
+    def test_other_wagtail_page_context(self):
+        other_page = HTMLPage.objects.get()
+        response = self.client.get(other_page.url)
+        self.assertEqual(response.context["ticketing_url"], self.EXAMPLE_URL)
+
+    def test_symposion_page_context(self):
+        response = self.client.get(reverse("account_login"))
+        self.assertEqual(response.context["ticketing_url"], self.EXAMPLE_URL)

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -101,6 +101,7 @@ TEMPLATE_CONTEXT_PROCESSORS = [
     "django_settings_export.settings_export",
     "symposion.reviews.context_processors.reviews",
     "wagtailmenus.context_processors.wagtailmenus",
+    "conf_site.cms.context_processors.homepage_context",
 ]
 
 

--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -155,11 +155,11 @@
                 <address>
                     <p></p>
                     <p class="soc">
-                        {% if page.footer_email %}
-                        <a href="mailto:{{ page.footer_email }}"><i class="fa fa-envelope"></i>Email</a>
+                        {% if footer_email %}
+                        <a href="mailto:{{ footer_email }}"><i class="fa fa-envelope"></i>Email</a>
                         {% endif %}
-                        {% if page.footer_twitter %}
-                        <a href="https://twitter.com/{{ page.footer_twitter }}/"><i class="fa fa-twitter"></i>Twitter</a>
+                        {% if footer_twitter %}
+                        <a href="https://twitter.com/{{ footer_twitter }}/"><i class="fa fa-twitter"></i>Twitter</a>
                         {% endif %}
                     </p>
                 </address>


### PR DESCRIPTION
  - Change how base template creates email and Twitter footer elements.
  - Remove custom get_context method from Wagtail pages.

This lets Wagtail and Symposion pages share the same information (ticketing link, mailing list ID, etc.).