### PR TITLE
Modify how page titles are generated.

### DIFF
--- a/conf_site/templates/403_csrf.html
+++ b/conf_site/templates/403_csrf.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}CSRF Error{% endblock %}
+{% block title %} - CSRF Error{% endblock %}
 
 {% block body %}
 <div class="container news-xl">

--- a/conf_site/templates/413.html
+++ b/conf_site/templates/413.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}PyData - File is too large!{% endblock %}
+{% block title %} - File is too large!{% endblock %}
 
 {% block body %}
 <div class="container news-xl">

--- a/conf_site/templates/account/email_confirm.html
+++ b/conf_site/templates/account/email_confirm.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Confirm Email" %}{% endblock %}
+{% block title %} - {% trans "Confirm Email" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/email_confirmation_sent.html
+++ b/conf_site/templates/account/email_confirmation_sent.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Confirm your email address" %}{% endblock %}
+{% block title %} - {% trans "Confirm your email address" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/email_confirmed.html
+++ b/conf_site/templates/account/email_confirmed.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Email confirmed" %}{% endblock %}
+{% block title %} - {% trans "Email confirmed" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/login.html
+++ b/conf_site/templates/account/login.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load bootstrap %}
 
-{% block title %}{% trans "Login" %}{% endblock %}
+{% block title %} - {% trans "Login" %}{% endblock %}
 
 {% block page_header %}{% trans "Login" %}{% endblock %}
 

--- a/conf_site/templates/account/logout.html
+++ b/conf_site/templates/account/logout.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Log out" %}{% endblock %}
+{% block title %} - {% trans "Log out" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/password_reset.html
+++ b/conf_site/templates/account/password_reset.html
@@ -4,7 +4,7 @@
 {% load bootstrap %}
 {% load account_tags %}
 
-{% block title %}{% trans "Password reset" %}{% endblock %}
+{% block title %} - {% trans "Password reset" %}{% endblock %}
 
 {% user_display request.user as user_display %}
 

--- a/conf_site/templates/account/password_reset_sent.html
+++ b/conf_site/templates/account/password_reset_sent.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load account_tags %}
 
-{% block title %}{% trans "Password reset sent" %}{% endblock %}
+{% block title %} - {% trans "Password reset sent" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/password_reset_token.html
+++ b/conf_site/templates/account/password_reset_token.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load bootstrap %}
 
-{% block title %}{% trans "Set your new password" %}{% endblock %}
+{% block title %} - {% trans "Set your new password" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/password_reset_token_fail.html
+++ b/conf_site/templates/account/password_reset_token_fail.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Bad token" %}{% endblock %}
+{% block title %} - {% trans "Bad token" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/signup.html
+++ b/conf_site/templates/account/signup.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load bootstrap %}
 
-{% block title %}{% trans "Sign up" %}{% endblock %}
+{% block title %} - {% trans "Sign up" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/account/signup_closed.html
+++ b/conf_site/templates/account/signup_closed.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Sign up" %}{% endblock %}
+{% block title %} - {% trans "Sign up" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{% block title %}{% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}</title>
+    <title>{{ conference_title }}{% block title %} - {% if self.seo_title %}{{ self.seo_title }}{% else %}{{ self.title }}{% endif %}{% endblock %}</title>
     <link href="https://fonts.googleapis.com/css?family=Dosis:400,700|Nunito|Open+Sans:300,400" rel="stylesheet">
     <link href="{% static 'css/font-awesome.css' %}" rel="stylesheet">
     <link href="{% static 'css/bootstrap.css' %}" rel="stylesheet">

--- a/conf_site/templates/dashboard.html
+++ b/conf_site/templates/dashboard.html
@@ -5,7 +5,7 @@
 {% load review_tags %}
 {% load teams_tags %}
 
-{% block title %}Dashboard{% endblock %}
+{% block title %} - Dashboard{% endblock %}
 
 {% block body_class %}auth{% endblock %}
 

--- a/conf_site/templates/homepage.html
+++ b/conf_site/templates/homepage.html
@@ -1,6 +1,9 @@
 {% extends "base.html" %}
 {% load sponsorship_tags wagtailcore_tags wagtailimages_tags %}
 {% load static from staticfiles %}
+
+{% block title %}{% endblock %}
+
 {% block body %}
 <div id="sli" class="text-center">
     <div class="bg-xc col-xs-12" data-stellar-background-ratio="1.1" data-stellar-vertical-offset="50"

--- a/conf_site/templates/symposion/conference/user_list.html
+++ b/conf_site/templates/symposion/conference/user_list.html
@@ -4,7 +4,7 @@
 {% load sitetree %}
 {% load static from staticfiles %}
 
-{% block title %}User List{% endblock %}
+{% block title %} - User List{% endblock %}
 
 {% block extra_head %}
     <style type="text/css">

--- a/conf_site/templates/symposion/proposals/document_create.html
+++ b/conf_site/templates/symposion/proposals/document_create.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap %}
 
-{% block title %}Upload Document to '{{ proposal.title }}'{% endblock %}
+{% block title %} - Upload Document to '{{ proposal.title }}'{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/proposals/proposal_cancel.html
+++ b/conf_site/templates/symposion/proposals/proposal_cancel.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans 'Cancel Proposal' %}{% endblock %}
+{% block title %} - {% trans 'Cancel Proposal' %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/proposals/proposal_detail.html
+++ b/conf_site/templates/symposion/proposals/proposal_detail.html
@@ -5,7 +5,7 @@
 {% load bootstrap %}
 {% load static from staticfiles %}
 
-{% block title %}{{ proposal.title }}{% endblock %}
+{% block title %} - {{ proposal.title }}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/proposals/proposal_edit.html
+++ b/conf_site/templates/symposion/proposals/proposal_edit.html
@@ -3,7 +3,7 @@
 {% load bootstrap %}
 {% load markitup_tags %}
 
-{% block title %}Editing {{ proposal.title }}{% endblock %}
+{% block title %} - Editing {{ proposal.title }}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/proposals/proposal_leave.html
+++ b/conf_site/templates/symposion/proposals/proposal_leave.html
@@ -1,5 +1,7 @@
 {% extends "base.html" %}
 
+{% block title %} - Leaving {{ proposal.title }}{% endblock %}
+
 {% block body %}
 <div class="container">
     <h3>Leaving {{ proposal.title }}</h3>

--- a/conf_site/templates/symposion/proposals/proposal_speaker_manage.html
+++ b/conf_site/templates/symposion/proposals/proposal_speaker_manage.html
@@ -3,6 +3,8 @@
 {% load i18n %}
 {% load bootstrap %}
 
+{% block title %} - Manage Speakers{% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>{% trans 'Proposal:' %} {{ proposal.title }}</h1>

--- a/conf_site/templates/symposion/proposals/proposal_submit.html
+++ b/conf_site/templates/symposion/proposals/proposal_submit.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}{% trans "Submit A Proposal" %}{% endblock %}
+{% block title %} - {% trans "Submit A Proposal" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/proposals/proposal_submit_kind.html
+++ b/conf_site/templates/symposion/proposals/proposal_submit_kind.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap i18n markitup_tags %}
 
-{% block title %}Submit a Proposal for a {{ kind.name }}{% endblock %}
+{% block title %} - Submit a Proposal for a {{ kind.name }}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/reviews/access_not_permitted.html
+++ b/conf_site/templates/symposion/reviews/access_not_permitted.html
@@ -1,5 +1,7 @@
 {% extends "symposion/reviews/base.html" %}
 
+{% block title %} - Access Not Permitted{% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>Access Not Permitted</h1>

--- a/conf_site/templates/symposion/reviews/base.html
+++ b/conf_site/templates/symposion/reviews/base.html
@@ -4,6 +4,8 @@
 {% load sitetree %}
 {% load static from staticfiles %}
 
+{% block title %} - Reviews{% endblock %}
+
 {% block extra_style %}
     <style type="text/css">
         div.dataTables_length label {

--- a/conf_site/templates/symposion/reviews/result_notification.html
+++ b/conf_site/templates/symposion/reviews/result_notification.html
@@ -2,6 +2,8 @@
 
 {% load i18n %}
 
+{% block title %} - Result Notification{% endblock %}
+
 {% block extra_style %}
     <style type="text/css">
         .table-striped tbody tr.selected td {

--- a/conf_site/templates/symposion/reviews/result_notification_prepare.html
+++ b/conf_site/templates/symposion/reviews/result_notification_prepare.html
@@ -2,9 +2,11 @@
 
 {% load i18n %}
 
+{% block title %} - Prepare Result Notification{% endblock %}
+
 {% block body %}
 <div class="container">
-    <h1>Result Notification Prepare</h1>
+    <h1>Prepare Result Notification</h1>
 
     <div class="row">
         <div class="col-md-4">

--- a/conf_site/templates/symposion/reviews/review_admin.html
+++ b/conf_site/templates/symposion/reviews/review_admin.html
@@ -1,5 +1,7 @@
 {% extends "symposion/reviews/base.html" %}
 
+{% block title %} - Reviewers{% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>Reviewers</h1>

--- a/conf_site/templates/symposion/reviews/review_assignment.html
+++ b/conf_site/templates/symposion/reviews/review_assignment.html
@@ -1,5 +1,7 @@
 {% extends "symposion/reviews/base.html" %}
 
+{% block title %} - Review Assignments{% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>Review Assignments</h1>

--- a/conf_site/templates/symposion/reviews/review_bulk_accept.html
+++ b/conf_site/templates/symposion/reviews/review_bulk_accept.html
@@ -2,6 +2,8 @@
 
 {% load bootstrap %}
 
+{% block title %} - Bulk Accept Reviews{% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>Bulk Accept</h1>

--- a/conf_site/templates/symposion/reviews/review_detail.html
+++ b/conf_site/templates/symposion/reviews/review_detail.html
@@ -6,6 +6,8 @@
 {% load account_tags %}
 {% load static from staticfiles %}
 
+{% block title %} - #{{ proposal.number }}: {{ proposal.title }} ({{ proposal.speaker }}){% endblock %}
+
 {% block extra_head %}
     <style type="text/css">
         body.reviews .markItUpEditor {

--- a/conf_site/templates/symposion/reviews/review_stats.html
+++ b/conf_site/templates/symposion/reviews/review_stats.html
@@ -1,5 +1,7 @@
 {% extends "symposion/reviews/base.html" %}
 
+{% block title %} - Voting Status ({{ section_slug }}){% endblock %}
+
 {% block body %}
 <div class="container">
     <h1>Voting Status ({{ section_slug }})</h1>

--- a/conf_site/templates/symposion/schedule/presentation_detail.html
+++ b/conf_site/templates/symposion/schedule/presentation_detail.html
@@ -2,7 +2,7 @@
 
 {% load sitetree %}
 
-{% block head_title %}Presentation: {{ presentation.title }}{% endblock %}
+{% block title %} - Presentation: {{ presentation.title }}{% endblock %}
 
 {% block breadcrumbs %}{% sitetree_breadcrumbs from "main" %}{% endblock %}
 

--- a/conf_site/templates/symposion/schedule/schedule_conference.html
+++ b/conf_site/templates/symposion/schedule/schedule_conference.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 
-{% block title %}Conference Schedule{% endblock %}
+{% block title %} - Conference Schedule{% endblock %}
 
 {% block body_class %}full{% endblock %}
 

--- a/conf_site/templates/symposion/schedule/schedule_detail.html
+++ b/conf_site/templates/symposion/schedule/schedule_detail.html
@@ -2,7 +2,7 @@
 
 {% load i18n sitetree %}
 
-{% block title %}Conference Schedule{% endblock %}
+{% block title %} - Conference Schedule{% endblock %}
 
 {% block body_class %}full{% endblock %}
 

--- a/conf_site/templates/symposion/schedule/schedule_edit.html
+++ b/conf_site/templates/symposion/schedule/schedule_edit.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load static from staticfiles %}
 
-{% block title %}Conference Schedule Edit{% endblock %}
+{% block title %} - Edit Conference Schedule{% endblock %}
 
 {% block body_class %}full{% endblock %}
 

--- a/conf_site/templates/symposion/schedule/schedule_list.html
+++ b/conf_site/templates/symposion/schedule/schedule_list.html
@@ -3,7 +3,7 @@
 {% load i18n %}
 {% load sitetree %}
 
-{% block title %}Presentation Listing{% endblock %}
+{% block title %} - Presentation Listing{% endblock %}
 
 {% block extra_head %}
     <style>

--- a/conf_site/templates/symposion/speakers/speaker_create.html
+++ b/conf_site/templates/symposion/speakers/speaker_create.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap i18n %}
 
-{% block title %}{% trans "Create Speaker Profile" %}{% endblock %}
+{% block title %} - {% trans "Create Speaker Profile" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/speakers/speaker_edit.html
+++ b/conf_site/templates/symposion/speakers/speaker_edit.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap i18n %}
 
-{% block title %}{% trans "Edit Speaker Profile" %}{% endblock %}
+{% block title %} - {% trans "Edit Speaker Profile" %}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/speakers/speaker_profile.html
+++ b/conf_site/templates/symposion/speakers/speaker_profile.html
@@ -4,7 +4,7 @@
 {% load thumbnail %}
 
 
-{% block title %}{{ speaker.name }}{% endblock %}
+{% block title %} - {{ speaker.name }}{% endblock %}
 
 {% block body %}
 <div class="container">

--- a/conf_site/templates/symposion/sponsorship/add.html
+++ b/conf_site/templates/symposion/sponsorship/add.html
@@ -3,7 +3,7 @@
 {% load bootstrap %}
 {% load i18n %}
 
-{% block title %}{% trans "Add a Sponsor" %}{% endblock %}
+{% block title %} - {% trans "Add a Sponsor" %}{% endblock %}
 
 {% block body_class %}sponsorships{% endblock %}
 

--- a/conf_site/templates/symposion/sponsorship/apply.html
+++ b/conf_site/templates/symposion/sponsorship/apply.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap i18n %}
 
-{% block title %}{% trans "Apply to be a Sponsor" %}{% endblock %}
+{% block title %} - {% trans "Apply to be a Sponsor" %}{% endblock %}
 
 {% block body_class %}sponsorships{% endblock %}
 

--- a/conf_site/templates/symposion/sponsorship/detail.html
+++ b/conf_site/templates/symposion/sponsorship/detail.html
@@ -3,7 +3,7 @@
 {% load bootstrap %}
 {% load i18n %}
 
-{% block title %}{{ sponsor }}{% endblock %}
+{% block title %} - {{ sponsor }}{% endblock %}
 
 {% block page_title %}{% trans "Sponsorship" %}{% endblock %}
 

--- a/conf_site/templates/symposion/sponsorship/list.html
+++ b/conf_site/templates/symposion/sponsorship/list.html
@@ -2,7 +2,7 @@
 
 {% load i18n markup sponsorship_tags %}
 
-{% block title %}{% trans "About Our Sponsors" %}{% endblock %}
+{% block title %} - {% trans "About Our Sponsors" %}{% endblock %}
 
 {% block body_class %}sponsorships{% endblock %}
 

--- a/conf_site/templates/symposion/teams/team_detail.html
+++ b/conf_site/templates/symposion/teams/team_detail.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap %}
 
-{% block title %}{{ team.name }}{% endblock %}
+{% block title %} - {{ team.name }}{% endblock %}
 
 {% block body_outer %}
 <div class="container">


### PR DESCRIPTION
Make sure that conference title appears at the beginning of every page title. Add titles to templates that do not have them.