### PR TITLE
Make display of proposal URL fields optional.

### DIFF
--- a/conf_site/proposals/forms.py
+++ b/conf_site/proposals/forms.py
@@ -45,6 +45,10 @@ class ProposalForm(forms.ModelForm):
         if not config.PROPOSAL_KEYWORDS:
             del self.fields["official_keywords"]
             del self.fields["user_keywords"]
+        # Don't display slide and code repo fields if support is disabled.
+        if not config.PROPOSAL_URL_FIELDS:
+            del self.fields["slides_url"]
+            del self.fields["code_url"]
 
     def clean_description(self):
         value = self.cleaned_data["description"]

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -263,6 +263,10 @@ CACHES = {
 CONFERENCE_ID = 1
 CONSTANCE_CONFIG = {
     "PROPOSAL_KEYWORDS": (False, "Support proposal keywords.", bool),
+    "PROPOSAL_URL_FIELDS": (
+        False,
+        "Show slides & code repository fields on proposal submission form.",
+        bool),
 }
 CSRF_FAILURE_VIEW = "conf_site.cms.views.csrf_failure"
 PROPOSAL_FORMS = {


### PR DESCRIPTION
Only display fields for proposal slides and code repositories on the
proposal submission form if a staff member has enabled this setting.