### PR TITLE
Improve overridden schedule slot CSS.

### DIFF
--- a/conf_site/static/css/mainstream-vc.css
+++ b/conf_site/static/css/mainstream-vc.css
@@ -703,13 +703,13 @@ table.calendar th{text-align:center}table.calendar th.time{width:60px}
 table.calendar td{text-align:center;vertical-align:middle}
 table.calendar td p {font-size:14px;}
 table.calendar td.time{vertical-align:top;padding-top:0;margin-top:0;color:#444;font-size:11px}
-table.calendar td.slot{font-weight:bold;text-shadow:#fff 0 1px 0}
+table.calendar td.slot{font-weight:bold;text-shadow:#fff 0 1px 0;vertical-align:middle}
 table.calendar td.slot.slot-break{background-color:#ecffff}
 table.calendar td.slot.slot-plenary{background-color:#ffffcc}
 table.calendar td.slot.slot-talk{background-color:#e1edf7}
 table.calendar td.slot.slot-tutorial{background-color:#fbe5d4}
 table.calendar td.slot.slot-discussion{background-color:#b8d9e3}
-table.calendar td.slot p{padding:0;margin:0}
+table.calendar td.slot p{padding:0;margin:0;line-height:20px}
 table.calendar td span.title{font-weight:bold;display:block}
 table.calendar td span.speaker{font-weight:normal;display:block}
 


### PR DESCRIPTION
  - Vertically align all schedule cells in the middle so that multi-hour events display in the middle of their cells, not at the top.
  - Since overridden slots automatically include paragraph elements, reduce slot paragraph line height to 20px to better fit in with other schedule items.