### PR TITLE
Modify venue banner image CSS styling.

### DIFF
--- a/conf_site/static/css/mainstream-vc.css
+++ b/conf_site/static/css/mainstream-vc.css
@@ -804,5 +804,6 @@ ul.dropdown-menu {
   }
     .bg-xc {height:100%;width:100%;position: absolute;background-size: cover !important;top: 0px;padding: 0px !important;overflow: hidden;background-position-x: 0px !important;}
     #sli {height:300px;position: relative;overflow: hidden;width: 100%;}
+    .venue-page #sli {min-height:600px;}
 
     .logo-ovr {position: absolute;top: 50px;display: block !important;width: 100%;text-align: center;z-index: 999;}

--- a/conf_site/templates/cms/venue_page.html
+++ b/conf_site/templates/cms/venue_page.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
 {% load wagtailcore_tags wagtailimages_tags %}
 
+{% block body_class %}venue-page{% endblock %}
+
 {% block body %}
 <div class="container sec1-inner-page">
 {% if page.background_image %}


### PR DESCRIPTION
Make banner image on venue pages display its normal height instead of just the top 300px like the homepage's banner image.