### PR TITLE
Fix presentation audience level display issue.

### DIFF
--- a/conf_site/proposals/tests/__init__.py
+++ b/conf_site/proposals/tests/__init__.py
@@ -11,12 +11,13 @@ class ProposalTestCase(TestCase):
     def setUp(self):
         # Create base conference infrastructure that has to exist in
         # order to create a Proposal.
-        conference = Conference(title="Conference")
-        conference.save()
-        section = Section(
-            conference=conference, name="Section", slug="section")
-        section.save()
-        proposal_kind = ProposalKind(section=section, name="Kind", slug="kind")
+        self.conference = Conference(title="Conference")
+        self.conference.save()
+        self.section = Section(
+            conference=self.conference, name="Section", slug="section")
+        self.section.save()
+        proposal_kind = ProposalKind(
+            section=self.section, name="Kind", slug="kind")
         proposal_kind.save()
         speaker = Speaker(name="Paul Ryan")
         speaker.save()

--- a/conf_site/proposals/tests/test_presentation_connection.py
+++ b/conf_site/proposals/tests/test_presentation_connection.py
@@ -1,0 +1,27 @@
+from symposion.conference.models import Section
+from symposion.proposals.models import ProposalBase
+from symposion.schedule.models import Presentation
+
+from conf_site.proposals.tests import ProposalTestCase
+
+
+class PresentationProposalConnectionTestCase(ProposalTestCase):
+    def test_presentation_proposal_model(self):
+        """Make sure presentation.proposal is Proposal, not ProposalBase."""
+        # Create Presentation connected to existing Proposal.
+        proposal_base = ProposalBase.objects.get(
+            title=self.proposal.title,
+            description=self.proposal.description,
+            abstract=self.proposal.abstract,
+            speaker=self.proposal.speaker,
+        )
+        presentation = Presentation.objects.create(
+            title=self.proposal.title,
+            description=self.proposal.description,
+            abstract=self.proposal.abstract,
+            speaker=self.proposal.speaker,
+            section=Section.objects.first(),
+            proposal_base=proposal_base,
+        )
+        # This should be a Proposal, not a ProposalBase.
+        self.assertIs(type(presentation.proposal), type(self.proposal))

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -23,4 +23,4 @@ wagtail==1.13.1
 wagtailmenus==2.6.0
 virtualenv==15.1.0
 
--e git+git://github.com/pydata/symposion.git@7de42e163cc649416705#egg=symposion
+-e git+git://github.com/pydata/symposion.git@5b9f9a5d8864465cb28a#egg=symposion


### PR DESCRIPTION
Fix issue with audience levels not displaying on presentation pages because `Presentation.proposal` was returning a `ProposalBase` instead of a `Proposal`. This is because symposion's dependency django-model-utils was not updated when upgrading to Django 1.11.