### PR TITLE
Only report "our" JavaScript errors.

### DIFF
--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -205,7 +205,9 @@
         integrity="sha384-HwE7dFvrH8iD9R5VYUqNwjIhxDycip+e4DjP5nEhXrJtACG8AdNXjvP+AfJWxhJh"
         crossorigin="anonymous"></script>
 <script>
-    Raven.config("{{ settings.SENTRY_PUBLIC_DSN }}").install()
+    Raven.config("{{ settings.SENTRY_PUBLIC_DSN }}", {
+        whitelistUrls: ["pydata.org"]
+    }).install()
 </script>
 {% endif %}
 <!--


### PR DESCRIPTION
Tell Sentry to only report errors from JavaScript hosted on pydata.org, to avoid spurious reports from people who block JQuery, etc.