### PR TITLE
Install wagtail-condensedinlinepanel.

### DIFF
--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -141,6 +141,7 @@ INSTALLED_APPS = [
     "analytical",
     "bootstrapform",
     "constance",
+    "condensedinlinepanel",
     "easy_thumbnails",
     "modelcluster",
     "pinax.eventlog",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,6 +20,7 @@ redis==2.10.6
 sendgrid-django==4.2.0
 unicodecsv==0.14.1
 wagtail==1.13.1
+wagtail-condensedinlinepanel==0.4.2
 wagtailmenus==2.6.0
 virtualenv==16.0.0
 


### PR DESCRIPTION
Install utility to reduce space used by inline panels in Wagtail CMS admin in order to improve management of menus. See https://wagtailmenus.readthedocs.io/en/v2.6.0/installation.html#installing-wagtail-condensedinlinepanel.