### PR TITLE
Modify password email templates.

### DIFF
--- a/conf_site/templates/account/email/email_confirmation_subject.txt
+++ b/conf_site/templates/account/email/email_confirmation_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name %}Confirm email address for {{ site_name }}{% endblocktrans %}
+{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Confirm your email address{% endblocktrans %}

--- a/conf_site/templates/account/email/invite_user_subject.txt
+++ b/conf_site/templates/account/email/invite_user_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans with name=current_site.name %}Create an account on {{ name }}{% endblocktrans %}
+{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Create an account{% endblocktrans %}

--- a/conf_site/templates/account/email/password_change.txt
+++ b/conf_site/templates/account/email/password_change.txt
@@ -1,1 +1,4 @@
-{% load i18n %}{% blocktrans with now=user.account.now %}This is the email notification to confirm your password has been changed on {{ now }}.{% endblocktrans %}
+{% load i18n %}
+{% blocktrans with now=user.account.now site_name=current_site.name %}
+This is an email notification from {{ site_name }} that your password was changed at {{ now }}.
+{% endblocktrans %}

--- a/conf_site/templates/account/email/password_change_subject.txt
+++ b/conf_site/templates/account/email/password_change_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Change password email notification{% endblocktrans %}
+{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Password change notification{% endblocktrans %}

--- a/conf_site/templates/account/email/password_change_subject.txt
+++ b/conf_site/templates/account/email/password_change_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% trans "Change password email notification" %}
+{% load i18n %}{% blocktrans with site_name=current_site.name %}[{{ site_name }}] Change password email notification{% endblocktrans %}


### PR DESCRIPTION
  - Standardize format of conference site name in subjects.
  - Make improvements to change password notification template.
  - Fix #245.