### PR TITLE
Change how SITE_ID setting is determined.

### DIFF
--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -30,7 +30,7 @@ TIME_ZONE = "US/Eastern"
 # http://www.i18nguy.com/unicode/language-identifiers.html
 LANGUAGE_CODE = "en-us"
 
-SITE_ID = int(os.environ.get("SITE_ID", 1))
+SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
 # to load the internationalization machinery.

--- a/conf_site/settings/development.py
+++ b/conf_site/settings/development.py
@@ -6,7 +6,6 @@ COMPRESS_ENABLED = False
 DEBUG = True
 SERVE_MEDIA = DEBUG
 
-SITE_ID = 2
 ALLOWED_HOSTS = ["localhost", "0.0.0.0"]
 
 DATABASES = {

--- a/conf_site/settings/production.py
+++ b/conf_site/settings/production.py
@@ -10,6 +10,4 @@ DATABASES = {
     "default": DATABASES_DEFAULT,       # noqa: F405
 }
 
-SITE_ID = 1
-
 SECURE_SSL_REDIRECT = True

--- a/conf_site/settings/staging.py
+++ b/conf_site/settings/staging.py
@@ -8,6 +8,4 @@ DATABASES = {
     "default": DATABASES_DEFAULT,       # noqa: F405
 }
 
-SITE_ID = 1
-
 SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
Always use SITE_ID = 1, with no exceptions, since "sites" fixture will automatically create a single correct Site object.