### PR TITLE
Upgrade wagtail to 1.13.4.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,7 +19,7 @@ raven==6.9.0
 redis==2.10.6
 sendgrid-django==4.2.0
 unicodecsv==0.14.1
-wagtail==1.13.2
+wagtail==1.13.4
 wagtail-condensedinlinepanel==0.4.2
 wagtailmenus==2.6.0
 virtualenv==16.0.0


### PR DESCRIPTION
  - http://docs.wagtail.io/en/v1.13.4/releases/1.13.3.html
  - http://docs.wagtail.io/en/v1.13.4/releases/1.13.4.html