### PR TITLE
Improve ability to format images through Wagtail.

### DIFF
--- a/conf_site/static/css/mainstream-vc.css
+++ b/conf_site/static/css/mainstream-vc.css
@@ -764,6 +764,20 @@ ul.dropdown-menu {
   text-decoration: none;
 }
 
+img.full-width {
+  display: block;
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+img.left {
+  float: left;
+  margin: 1em;
+}
+img.right {
+  float: right;
+  margin: 1em;
+}
+
 @media (max-width: 1500px) {
   #sec1x-con .sec1-col, #nst-con .vcs { margin-left: 150px; }
 }

--- a/conf_site/urls.py
+++ b/conf_site/urls.py
@@ -14,6 +14,7 @@ import symposion.views
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtailcore import urls as wagtail_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
+from wagtail.wagtailimages.views.serve import ServeView as WagtailImageView
 
 from cms.views import csrf_failure, LoginEmailView
 from conf_site.reviews.views import (
@@ -37,6 +38,11 @@ urlpatterns += [
     url(r"^cms/", include(wagtailadmin_urls)),
     url(r"^dashboard/", symposion.views.dashboard, name="dashboard"),
     url(r"^documents/", include(wagtaildocs_urls)),
+    url(
+        r"^images/([^/]*)/(\d*)/([^/]*)/[^/]*$",
+        WagtailImageView.as_view(action="redirect"),
+        name="wagtailimages_serve",
+    ),
     url(r"^speaker/export/$",
         staff_member_required(ExportAcceptedSpeakerEmailView.as_view()),
         name="speaker_email_export"),


### PR DESCRIPTION
  - Add "image generator" allowing staff to generate new images with variable widths and heights from uploaded images in Wagtail.
  - Add CSS so that staff can add images directly in rich text editing widgets.
