### PR TITLE
Fix display of userless speakers.

### DIFF
--- a/symposion/schedule/models.py
+++ b/symposion/schedule/models.py
@@ -250,8 +250,7 @@ class Presentation(models.Model):
     def speakers(self):
         yield self.speaker
         for speaker in self.additional_speakers.all():
-            if speaker.user:
-                yield speaker
+            yield speaker
 
     def __str__(self):
         return "#%s %s (%s)" % (self.number, self.title, self.speaker)

--- a/symposion/schedule/tests/test_userless_speakers.py
+++ b/symposion/schedule/tests/test_userless_speakers.py
@@ -1,0 +1,67 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from symposion.conference.models import Conference, Section
+from symposion.proposals.models import (
+    ProposalBase,
+    ProposalKind,
+)
+from symposion.speakers.models import Speaker
+from symposion.schedule.models import Presentation
+
+
+class UserlessSpeakersTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        # Create two speakers - one with a User attached, and one without.
+        user_model = get_user_model()
+        user = user_model.objects.create(
+            username="test",
+            email="example@example.com",
+            first_name="Test",
+            last_name="User",
+        )
+        primary_speaker = Speaker.objects.create(user=user, name="Speaker #1")
+        cls.second_speaker = Speaker.objects.create(
+            user=None, name="Speaker #2"
+        )
+
+        # A Presentation needs a ProposalBase, and
+        # a ProposalBase needs a ProposalKind, and
+        # a ProposalKind needs a Section, and
+        # A Section needs a Conference, and
+        # the developer who wrote this test case needs a hug!
+        conference = Conference.objects.create(title="Conference")
+        section = Section.objects.create(
+            conference=conference, name="Section", slug="section"
+        )
+        proposal_kind = ProposalKind.objects.create(
+            section=section, name="Proposal Kind", slug="kind"
+        )
+        proposal_base = ProposalBase.objects.create(
+            title="Proposal",
+            description="...",
+            abstract="...",
+            speaker=primary_speaker,
+            kind=proposal_kind,
+        )
+        cls.presentation = Presentation.objects.create(
+            title="Presentation",
+            description="...",
+            abstract="...",
+            speaker=primary_speaker,
+            proposal_base=proposal_base,
+            section=section,
+        )
+        cls.presentation.additional_speakers.add(cls.second_speaker)
+
+    def test_userless_speaker_name(self):
+        """Test that userless speakers will display their names."""
+        self.assertEqual(str(self.second_speaker), self.second_speaker.name)
+
+    def test_presentation_userless_speakers(self):
+        """Test that presentation speaker counts include all speakers."""
+        # A Presentation's speakers() method is a generator of all
+        # associated speakers. If it is properly returning all speakers
+        # (regardless of user status), the result should be two.
+        self.assertEqual(len(list(self.presentation.speakers())), 2)

--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -80,10 +80,7 @@ class Speaker(models.Model):
         return super(Speaker, self).save(*args, **kwargs)
 
     def __str__(self):
-        if self.user:
-            return self.name
-        else:
-            return "?"
+        return self.name
 
     def get_absolute_url(self):
         return reverse("speaker_edit")


### PR DESCRIPTION
  - Ensure that the names of userless speakers display on website
    instead of `?`. Since all speakers must have names, displaying a
    question mark is not necessary.
  - Ensure that userless speakers display on schedule and presentation
    pages. This behavior is inconsistent with that of proposals.