### PR TITLE
Hotfix for 4a36aee. Fix secondary speakers.

### DIFF
--- a/symposion/speakers/tests/test_speaker_profile.py
+++ b/symposion/speakers/tests/test_speaker_profile.py
@@ -96,3 +96,15 @@ class SpeakerProfilePresentationsTestCase(TestCase):
         )
         self.assertContains(response, FIRST_PRESENTATION_TITLE)
         self.assertNotContains(response, SECOND_PRESENTATION_TITLE)
+
+    def test_second_speaker_profile_page(self):
+        """Verify that a second speaker's profile page is public."""
+        second_speaker = Speaker.objects.create(name="Nancy Pelosi")
+        self.first_presentation.additional_speakers.add(second_speaker)
+
+        response = self.client.get(
+            reverse("speaker_profile", args=[second_speaker.pk])
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, FIRST_PRESENTATION_TITLE)
+        self.assertNotContains(response, SECOND_PRESENTATION_TITLE)

--- a/symposion/speakers/views.py
+++ b/symposion/speakers/views.py
@@ -135,7 +135,9 @@ def speaker_edit(request, pk=None):
 
 def speaker_profile(request, pk):
     speaker = get_object_or_404(Speaker, pk=pk)
-    presentations = list(speaker.presentations.exclude(slot=None))
+    presentations = list(speaker.presentations.exclude(slot=None)) + list(
+        speaker.copresentations.exclude(slot=None)
+    )
     if not presentations and not request.user.is_staff:
         raise Http404()
 


### PR DESCRIPTION
Ensure that profile pages for secondary speakers appear, while retaining
new fix to prevent unscheduled presentations from appearing.