### PR TITLE
Fix "raw" issue with "schedule_json" view.

### DIFF
--- a/symposion/schedule/tests/factories.py
+++ b/symposion/schedule/tests/factories.py
@@ -7,6 +7,7 @@ from factory import fuzzy
 
 from symposion.schedule.models import Schedule, Day, Slot, SlotKind
 from symposion.conference.models import Section, Conference
+from symposion.proposals.models import ProposalKind
 
 
 class ConferenceFactory(factory.DjangoModelFactory):
@@ -29,6 +30,15 @@ class SectionFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = Section
+
+
+class ProposalKindFactory(factory.DjangoModelFactory):
+    section = factory.SubFactory(SectionFactory)
+    name = fuzzy.FuzzyText()
+    slug = fuzzy.FuzzyText()
+
+    class Meta:
+        model = ProposalKind
 
 
 class ScheduleFactory(factory.DjangoModelFactory):

--- a/symposion/schedule/views.py
+++ b/symposion/schedule/views.py
@@ -207,8 +207,8 @@ def schedule_json(request):
                     "contact": [s.email for s in slot.content.speakers()]
                     if request.user.is_staff
                     else ["redacted"],
-                    "abstract": slot.content.abstract.raw,
-                    "description": slot.content.description.raw,
+                    "abstract": slot.content.abstract,
+                    "description": slot.content.description,
                     "conf_url": "%s://%s%s"
                     % (
                         protocol,


### PR DESCRIPTION
Fix broken presentation abstract and descriptions causing error when
generating a conference's schedule JSON. See #315 and https://sentry.io/mobolic/conference-sites/issues/846616460.