### PR TITLE
Fix broken settings export to template context.

### DIFF
--- a/ansible/roles/web/templates/sensitive-settings.py
+++ b/ansible/roles/web/templates/sensitive-settings.py
@@ -58,8 +58,4 @@ SENTRY_PUBLIC_DSN = False
 
 GOOGLE_ANALYTICS_PROPERTY_ID = "{{ google_analytics_id }}"
 
-SETTINGS_EXPORT = [
-    "GOOGLE_ANALYTICS_PROPERTY_ID",
-    "SENTRY_PUBLIC_DSN",
-]
 WAGTAIL_SITE_NAME = "{{ conference_name }}"

--- a/conf_site/core/context_processors.py
+++ b/conf_site/core/context_processors.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+def core_context(self):
+    """Context processor for elements appearing on every page."""
+    context = {}
+    context["google_analytics_id"] = settings.GOOGLE_ANALYTICS_PROPERTY_ID
+    context["sentry_public_dsn"] = settings.SENTRY_PUBLIC_DSN
+    return context

--- a/conf_site/core/tests/test_core_context.py
+++ b/conf_site/core/tests/test_core_context.py
@@ -1,0 +1,25 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+
+class CoreContextProcessorTestCase(TestCase):
+    def test_google_analytics_id(self):
+        """Verify that Google Analytics ID appears in the context & HTML."""
+        GA_EXAMPLE_ID = "UA-1234567-88"
+        with self.settings(GOOGLE_ANALYTICS_PROPERTY_ID=GA_EXAMPLE_ID):
+            # This URL shouldn't matter - all pages should have GA information.
+            response = self.client.get(reverse("account_login"))
+            self.assertEqual(
+                response.context.get("google_analytics_id"), GA_EXAMPLE_ID
+            )
+            self.assertContains(response, GA_EXAMPLE_ID)
+
+    def test_sentry_public_dsn(self):
+        """Verify that the Sentry public DSN appears in context & HTML."""
+        SENTRY_PUBLIC_DSN = "https://SUPERB@sentry.io/OWL"
+        with self.settings(SENTRY_PUBLIC_DSN=SENTRY_PUBLIC_DSN):
+            response = self.client.get(reverse("account_login"))
+            self.assertEqual(
+                response.context.get("sentry_public_dsn"), SENTRY_PUBLIC_DSN
+            )
+            self.assertContains(response, SENTRY_PUBLIC_DSN)

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -98,10 +98,10 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "account.context_processors.account",
                 "constance.context_processors.config",
-                "django_settings_export.settings_export",
                 "symposion.reviews.context_processors.reviews",
                 "wagtailmenus.context_processors.wagtailmenus",
                 "wagtail.contrib.settings.context_processors.settings",
+                "conf_site.core.context_processors.core_context",
                 "conf_site.cms.context_processors.homepage_context",
             ]
         },

--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -46,7 +46,7 @@
     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', '{{ settings.GOOGLE_ANALYTICS_PROPERTY_ID }}', 'auto');
+    ga('create', '{{ google_analytics_id }}', 'auto');
     ga('require', 'eventTracker');
     ga('require', 'outboundFormTracker');
     ga('require', 'outboundLinkTracker');
@@ -207,12 +207,12 @@
 <script src="{% static 'js/retina.min.js' %}"></script>
 <script src="{% static 'js/jquery.sticky.js' %}"></script>
 <script src="{% static 'js/jquery.stellar.js' %}"></script>
-{% if settings.SENTRY_PUBLIC_DSN %}
+{% if sentry_public_dsn %}
 <script src="https://cdn.ravenjs.com/3.26.4/raven.min.js"
         integrity="sha384-7zaZhdtWTKq5xNtp4WyvUJvEQ+aETU+FlQnpLIbepx2bQAee8znJJjmlydqQjbn/"
         crossorigin="anonymous"></script>
 <script>
-    Raven.config("{{ settings.SENTRY_PUBLIC_DSN }}", {
+    Raven.config("{{ sentry_public_dsn }}", {
         whitelistUrls: ["pydata.org"]
     }).install()
 </script>

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,6 @@ django-multiselectfield==0.1.8
 django-redis-cache==1.7.1
 djangorestframework==3.8.2
 django-reversion==2.0.13
-django-settings-export==1.2.1
 django-taggit==0.23.0
 django-timezone-field==3.0
 django-user-accounts==1.3.1


### PR DESCRIPTION
Integrating [wagtail's settings application](https://docs.wagtail.io/en/v1.13.4/reference/contrib/settings.html) for site-specific sponsor information (see #292) introduced a conflict with [django_settings_export](https://github.com/jakubroztocil/django-settings-export) which caused it to no longer export settings to the template's context. This caused all conference site Google Analytics IDs to stop displaying properly and no errors to be reported to Sentry. :sob: 

Since there is no way to tell either application to stop using the "settings" namespace (see wagtail/wagtail#4753), this commit stops using django_settings_export and creates a custom context processor to store the relevant information. It includes two simple automated tests to ensure that they appear in both the response's context and HTML.