### PR TITLE
Fix proposal_speaker_manage view.

### DIFF
--- a/conf_site/proposals/tests/test_proposal_management.py
+++ b/conf_site/proposals/tests/test_proposal_management.py
@@ -42,3 +42,16 @@ class ProposalSpeakerManageViewTestCase(ProposalTestCase):
             reverse("proposal_speaker_manage", args=[self.proposal.pk])
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_inviting_speaker(self):
+        """Verify that inviting a speaker works."""
+        response = self.client.post(
+            path=reverse("proposal_speaker_manage", args=[self.proposal.pk]),
+            data={"email": "valid@example.com"},
+            follow=True,
+        )
+        self.assertRedirects(
+            response,
+            reverse("proposal_speaker_manage", args=[self.proposal.pk]),
+        )
+        self.assertContains(response, "Speaker invited to proposal.")

--- a/conf_site/proposals/tests/test_proposal_management.py
+++ b/conf_site/proposals/tests/test_proposal_management.py
@@ -1,0 +1,44 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils.crypto import get_random_string
+
+from symposion.speakers.models import Speaker
+
+from conf_site.proposals.tests import ProposalTestCase
+
+
+class ProposalSpeakerManageViewTestCase(ProposalTestCase):
+    """Automated test cases for symposion's proposal_speaker_manage view."""
+
+    def setUp(self):
+        super(ProposalSpeakerManageViewTestCase, self).setUp()
+        user_model = get_user_model()
+        USER_EMAIL = "example@example.com"
+        USER_PASSWORD = get_random_string()
+        self.user = user_model.objects.create_user(
+            username="user", email=USER_EMAIL, password=USER_PASSWORD
+        )
+        speaker = Speaker.objects.create(name="Nancy Pelosi")
+        speaker.user = self.user
+        speaker.save()
+
+        # Overwrite speaker for this case's proposal - sorry, Paul Ryan.
+        self.proposal.speaker = speaker
+        self.proposal.save()
+
+        self.assertTrue(
+            self.client.login(username=USER_EMAIL, password=USER_PASSWORD)
+        )
+
+    def test_verify_proposal_jacking_does_not_work(self):
+        """Verify that you can't manage a proposal that is not yours."""
+        # Create a new speaker and change ownership of this
+        # test case's Proposal to said speaker.
+        other_speaker = Speaker.objects.create(name="Other Speaker")
+        self.proposal.speaker = other_speaker
+        self.proposal.save()
+
+        response = self.client.get(
+            reverse("proposal_speaker_manage", args=[self.proposal.pk])
+        )
+        self.assertEqual(response.status_code, 404)

--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -58,6 +58,11 @@
 <body class="{% block body_class %}{% endblock %}">
 {% wagtailuserbar "bottom-left" %}
 <header>
+    {% if messages %}
+    <div id="stp1" class="text-center">
+        {% for message in messages %}<h3>{{ message }}</h3>{% endfor %}
+    </div>
+    {% endif %}
     {% if cfp_open %}
     <div id="stp1" class="text-center">
         <h3><a href="./cfp/">CALL FOR PROPOSALS <strong>NOW OPEN!</strong></a></h3>

--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -1,6 +1,4 @@
 from __future__ import unicode_literals
-import hashlib
-import random
 import sys
 
 from django.conf import settings
@@ -14,6 +12,7 @@ from django.views import static
 from django.contrib import messages
 from django.contrib.auth.models import User
 
+from django.utils.crypto import get_random_string
 from django.utils.translation import ugettext_lazy as _
 
 from account.decorators import login_required
@@ -138,8 +137,7 @@ def proposal_speaker_manage(request, pk):
                         Q(user=None, invite_email=email_address)
                     )
                 except Speaker.DoesNotExist:
-                    salt = hashlib.sha1(str(random.random())).hexdigest()[:5]
-                    token = hashlib.sha1(salt + email_address).hexdigest()
+                    token = get_random_string(5)
                     pending = Speaker.objects.create(
                         invite_email=email_address, invite_token=token
                     )


### PR DESCRIPTION
  - Add missing messages to base template.
  - Add automated tests to proposal_speaker_manage view.
  - Add Python 3 regression involving strings/bytes that was missed because of forementioned lack of automated tests.