### PR TITLE
Add fixture for default django-user-accounts data.

### DIFF
--- a/ansible/roles/web/templates/fixtures/django_user_accounts_accounts.json
+++ b/ansible/roles/web/templates/fixtures/django_user_accounts_accounts.json
@@ -1,0 +1,97 @@
+[
+{
+    "model": "account.account",
+    "pk": 2,
+    "fields": {
+        "user": 2,
+        "timezone": "",
+        "language": "en-us"
+    }
+},
+{
+    "model": "account.emailaddress",
+    "pk": 2,
+    "fields": {
+        "user": 2,
+        "email": "martey+pydata.org@mobolic.com",
+        "verified": false,
+        "primary": true
+    }
+},
+{
+    "model": "account.account",
+    "pk": 3,
+    "fields": {
+        "user": 3,
+        "timezone": "",
+        "language": "en-us"
+    }
+},
+{
+    "model": "account.emailaddress",
+    "pk": 3,
+    "fields": {
+        "user": 3,
+        "email": "leah@numfocus.org",
+        "verified": false,
+        "primary": true
+    }
+},
+{
+    "model": "account.account",
+    "pk": 4,
+    "fields": {
+        "user": 4,
+        "timezone": "",
+        "language": "en-us"
+    }
+},
+{
+    "model": "account.emailaddress",
+    "pk": 4,
+    "fields": {
+        "user": 4,
+        "email": "jim@numfocus.org",
+        "verified": false,
+        "primary": true
+    }
+},
+{
+    "model": "account.account",
+    "pk": 5,
+    "fields": {
+        "user": 5,
+        "timezone": "",
+        "language": "en-us"
+    }
+},
+{
+    "model": "account.emailaddress",
+    "pk": 5,
+    "fields": {
+        "user": 5,
+        "email": "gina@numfocus.org",
+        "verified": false,
+        "primary": true
+    }
+},
+{
+    "model": "account.account",
+    "pk": 6,
+    "fields": {
+        "user": 6,
+        "timezone": "",
+        "language": "en-us"
+    }
+},
+{
+    "model": "account.emailaddress",
+    "pk": 6,
+    "fields": {
+        "user": 6,
+        "email": "andy@numfocus.org",
+        "verified": false,
+        "primary": true
+    }
+}
+]


### PR DESCRIPTION
Create default data for DUA's Account and EmailAddress models.

Note that the fixture containing django-user-accounts data **must** be alphabetically after the fixture containing django.contrib.auth.models.User data.