### PR TITLE
Do not display "Notes" when blind reviewing is on.

### DIFF
--- a/conf_site/reviews/tests/test_proposal_detail_view.py
+++ b/conf_site/reviews/tests/test_proposal_detail_view.py
@@ -44,6 +44,22 @@ class ProposalDetailViewAccessTestCase(ReviewingTestCase, AccountsTestCase):
             self.assertNotContains(response, self.reviewer.user.username)
             self.assertNotContains(response, self.reviewer.email)
 
+    def test_blind_reviewing_means_no_notes_section(self):
+        """
+        Verify that the Notes section does not appear if BLIND_REVIEWERS is on.
+        """
+        self._add_to_reviewers_group()
+        # Set this proposal's notes field to something memorable.
+        self.proposal.additional_notes = "xyzzy"
+        self.proposal.save()
+
+        with override_config(BLIND_REVIEWERS=True):
+            response = self.client.get(
+                reverse(self.reverse_view_name, args=self.reverse_view_args)
+            )
+            self.assertNotContains(response, "Notes")
+            self.assertNotContains(response, self.proposal.additional_notes)
+
     def test_author_cannot_view_votes_tab(self):
         """Verify that proposal authors cannot view their proposal's votes."""
         self._i_am_the_author_now()

--- a/conf_site/templates/symposion/proposals/_proposal_fields.html
+++ b/conf_site/templates/symposion/proposals/_proposal_fields.html
@@ -47,8 +47,10 @@
     <dt>{% trans "Abstract" %}</dt>
     <dd>{{ proposal.abstract_html|safe }}&nbsp;</dd>
 
+    {% if not config.BLIND_REVIEWERS or request.user.is_superuser %}
     <dt>{% trans "Notes" %}</dt>
     <dd>{{ proposal.additional_notes_html|safe }}&nbsp;</dd>
+    {% endif %}
 
     {% if config.PROPOSAL_URL_FIELDS %}
         {% if proposal.slides_url %}


### PR DESCRIPTION
Do not display a proposal's "Notes" section when blind reviewing is enabled.