### PR TITLE
Handle proposals that do not exist.

### DIFF
--- a/conf_site/reviews/views/__init__.py
+++ b/conf_site/reviews/views/__init__.py
@@ -31,10 +31,13 @@ class ReviewingView(UserPassesTestMixin, View):
         # If allow_speakers is enabled, speakers get access.
         if self.allow_speakers:
             # Test whether user is one of the proposal's speakers.
-            proposal = Proposal.objects.get(pk=self.kwargs["pk"])
-            for speaker in proposal.speakers():
-                if self.request.user == speaker.user:
-                    return True
+            try:
+                proposal = Proposal.objects.get(pk=self.kwargs["pk"])
+                for speaker in proposal.speakers():
+                    if self.request.user == speaker.user:
+                        return True
+            except Proposal.DoesNotExist:
+                pass
         # Users in the Reviewers group also get access.
         return reviewers_group in self.request.user.groups.all()
 


### PR DESCRIPTION
https://sentry.io/organizations/mobolic/issues/1026483340/

Ignore exception if a user tries to access a reviewing view for a proposal that does not exist.

We ignore the exception to avoid showing 403 errors to valid reviewers who might have accessed the wrong link - the necessary child view should show a 404 if necessary.