### PR TITLE
Hotfix security issue allowing some proposal speakers to see reviews.

### DIFF
--- a/conf_site/templates/reviews/proposal_detail.html
+++ b/conf_site/templates/reviews/proposal_detail.html
@@ -6,7 +6,9 @@
 
 {% block body %}
 <div class="container">
+  {% if actor == "reviewer" or  request.user.is_superuser %}
     {% include "reviews/_proposal_mini_navigation.html" %}
+  {% endif %}
   <h2>{{ proposal.title }}</h2>
 
   {% if config.BLIND_REVIEWERS and request.user.is_superuser %}


### PR DESCRIPTION
Modify logic in `ProposalDetailView` context generation so that speakers who were neither first nor last in proposals with 3 or more speakers can't view their proposal's reviews. Fix unrelated bug where proposal speakers could see (albeit not visit) a link to the "All Proposals" view.