### PR TITLE
Improve generation of login URL.

### DIFF
--- a/conf_site/speakers/tests/test_speaker_list.py
+++ b/conf_site/speakers/tests/test_speaker_list.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 
@@ -48,7 +49,7 @@ class SpeakerListViewTestCase(AccountsTestCase):
         # Regular users should get redirected to the login page,
         # because SpeakerListView.raise_exception is False.
         login_url_redirecting_to_speaker_list = "{}?next={}".format(
-            reverse("account_login"), reverse("speaker_list")
+            settings.LOGIN_URL, reverse("speaker_list")
         )
         self.assertEqual(response.url, login_url_redirecting_to_speaker_list)
 


### PR DESCRIPTION
Hotfix for #379. Change how login URL is generated in automated test so that tests will still pass in environments with custom LOGIN_URLs set up.