### PR TITLE
 Prevent duplicate email addresses in speaker feedback notifications.

### DIFF
--- a/conf_site/reviews/tests/__init__.py
+++ b/conf_site/reviews/tests/__init__.py
@@ -6,8 +6,9 @@ from django.urls import reverse
 
 from constance.test import override_config
 
-from conf_site.proposals.tests.factories import ProposalFactory
+from conf_site.proposals.tests.factories import ProposalFactory, SpeakerFactory
 from conf_site.reviews.tests.factories import ProposalFeedbackFactory
+from symposion.proposals.models import AdditionalSpeaker
 
 
 class ReviewingTestCase(object):
@@ -34,6 +35,25 @@ class ReviewingTestCase(object):
             return [self.proposal]
         except AttributeError:
             return ProposalFactory.create_batch(size=randint(2, 5))
+
+    def _i_am_the_speaker_now(self):
+        """Make this testcase's user the primary speaker of the proposal."""
+        # Create a reviewer (as a speaker profile).
+        self.reviewer = SpeakerFactory()
+        # Attach current user as the primary speaker on this proposal.
+        self.proposal.speaker.user = self.user
+        self.proposal.speaker.save()
+
+    def _i_am_also_a_speaker_now(self):
+        """Make this testcase's user an additional speaker on the proposal."""
+        self.reviewer = SpeakerFactory()
+        self.reviewer.user = self.user
+        self.reviewer.save()
+        AdditionalSpeaker.objects.create(
+            proposalbase=self.proposal.proposalbase_ptr,
+            speaker=self.reviewer,
+            status=AdditionalSpeaker.SPEAKING_STATUS_ACCEPTED,
+        )
 
     def setUp(self):
         super(ReviewingTestCase, self).setUp()

--- a/conf_site/reviews/tests/test_proposal_detail_view.py
+++ b/conf_site/reviews/tests/test_proposal_detail_view.py
@@ -6,9 +6,8 @@ from constance.test import override_config
 from conf_site.accounts.tests import AccountsTestCase
 from conf_site.reviews.tests import ReviewingTestCase
 
-from conf_site.proposals.tests.factories import ProposalFactory, SpeakerFactory
+from conf_site.proposals.tests.factories import ProposalFactory
 from conf_site.reviews.tests.factories import ProposalFeedbackFactory
-from symposion.proposals.models import AdditionalSpeaker
 
 
 class ProposalDetailViewAccessTestCase(ReviewingTestCase, AccountsTestCase):
@@ -18,25 +17,6 @@ class ProposalDetailViewAccessTestCase(ReviewingTestCase, AccountsTestCase):
         super(ProposalDetailViewAccessTestCase, self).setUp()
         self.proposal = ProposalFactory()
         self.reverse_view_args = [self.proposal.pk]
-
-    def _i_am_the_speaker_now(self):
-        """Make this testcase's user the primary speaker of the proposal."""
-        # Create a reviewer (as a speaker profile).
-        self.reviewer = SpeakerFactory()
-        # Attach current user as the primary speaker on this proposal.
-        self.proposal.speaker.user = self.user
-        self.proposal.speaker.save()
-
-    def _i_am_also_a_speaker_now(self):
-        """Make this testcase's user an additional speaker on the proposal."""
-        self.reviewer = SpeakerFactory()
-        self.reviewer.user = self.user
-        self.reviewer.save()
-        AdditionalSpeaker.objects.create(
-            proposalbase=self.proposal.proposalbase_ptr,
-            speaker=self.reviewer,
-            status=AdditionalSpeaker.SPEAKING_STATUS_ACCEPTED,
-        )
 
     def test_blind_reviewing_types_as_author(self):
         """Verify whether BLIND_AUTHORS setting works properly."""

--- a/conf_site/reviews/tests/test_proposal_feedback_posting.py
+++ b/conf_site/reviews/tests/test_proposal_feedback_posting.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from django.core import mail
+from django.urls import reverse
+
+from faker import Faker
+
+
+from conf_site.accounts.tests import AccountsTestCase
+from conf_site.accounts.tests.factories import UserFactory
+from conf_site.proposals.tests.factories import ProposalFactory
+from conf_site.reviews.tests import ReviewingTestCase
+from conf_site.reviews.tests.factories import ProposalFeedbackFactory
+
+
+class ProposalFeedbackPostingTestCase(ReviewingTestCase, AccountsTestCase):
+    http_method_name = "post"
+    reverse_view_name = "review_proposal_feedback"
+
+    def setUp(self):
+        super(ProposalFeedbackPostingTestCase, self).setUp()
+
+        self.faker = Faker()
+        self.proposal = ProposalFactory()
+        self.reverse_view_args = [self.proposal.pk]
+        self.reverse_view_data = {
+            "comment": self.faker.paragraph(
+                nb_sentences=5, variable_nb_sentences=True
+            )
+        }
+
+    def _get_response(self):
+        return self.client.post(
+            reverse(self.reverse_view_name, args=self.reverse_view_args),
+            data=self.reverse_view_data,
+            follow=True,
+        )
+
+    def _duplicate_email_addresses(self, message):
+        """
+        Helper method to find if an email message contains duplicate addresses.
+        """
+        seen_addresses = []
+
+        def _search_for_duplicates(email_field):
+            for address in email_field:
+                if address in seen_addresses:
+                    return True
+                else:
+                    seen_addresses.append(address)
+
+        _search_for_duplicates(message.to)
+        _search_for_duplicates(message.cc)
+        _search_for_duplicates(message.bcc)
+        return False
+
+    def test_no_duplicate_speaker_emails_when_sending_feedback(self):
+        self._add_to_reviewers_group()
+        # Create multiple existing proposal feedback authored by the speaker.
+        ProposalFeedbackFactory.create_batch(
+            proposal=self.proposal, author=self.proposal.speaker.user, size=3
+        )
+
+        response = self._get_response()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(mail.outbox), 2)
+        for message in mail.outbox:
+            self.assertFalse(self._duplicate_email_addresses(message))
+
+    def test_no_duplicate_reviewer_emails_when_sending_feedback(self):
+        self._i_am_the_speaker_now()
+        # Create multiple existing proposal feedback authored by a random user.
+        random_user = UserFactory()
+        ProposalFeedbackFactory.create_batch(
+            proposal=self.proposal, author=random_user, size=3
+        )
+
+        response = self._get_response()
+
+        self.assertEqual(response.status_code, 200)
+        # There should be only one message sent - to the random user.
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertEqual(mail.outbox[0].to, [random_user.email])
+        self.assertFalse(self._duplicate_email_addresses(mail.outbox[0]))

--- a/conf_site/reviews/views/__init__.py
+++ b/conf_site/reviews/views/__init__.py
@@ -135,6 +135,7 @@ class ProposalFeedbackPostView(ReviewingView):
                 speaker.email
                 and speaker.user
                 and speaker.user != self.request.user
+                and speaker.email not in speaker_email_addressses
             ):
                 speaker_email_addressses.append(speaker.email)
         send_email(
@@ -149,7 +150,11 @@ class ProposalFeedbackPostView(ReviewingView):
         # Send email to reviewers.
         reviewer_email_addresses = []
         for feedback in proposal.review_feedback.all():
-            if feedback.author.email and feedback.author != self.request.user:
+            if (
+                feedback.author.email
+                and feedback.author != self.request.user
+                and feedback.author.email not in reviewer_email_addresses
+            ):
                 reviewer_email_addresses.append(feedback.author.email)
         send_email(
             reviewer_email_addresses,


### PR DESCRIPTION
De-duplicate email addresses used when notifying about speaker feedback. Since SendGrid's API does not allow sending multiple copies of the same email message to a single address, this will help prevent failures when there are already existing feedback messages.