### PR TITLE
Change dialect used to create exported CSV files.

### DIFF
--- a/conf_site/core/views.py
+++ b/conf_site/core/views.py
@@ -43,7 +43,7 @@ class CsvView(View):
         )
 
         # Initialize CSV file.
-        self.csv_writer = csv.writer(self.temp_file)
+        self.csv_writer = csv.writer(self.temp_file, dialect=csv.unix_dialect)
 
     def get(self, *args, **kwargs):
         # Make sure that everything has been saved.

--- a/conf_site/proposals/tests/test_exporting_proposal_submitters.py
+++ b/conf_site/proposals/tests/test_exporting_proposal_submitters.py
@@ -18,7 +18,11 @@ class ExportProposalSubmittersViewTestCase(AccountsTestCase):
         """Verify that header row appears in CSV file response."""
         view = ExportProposalSubmittersView()
         response = view.get()
-        self.assertContains(response, ",".join(view.header_row))
+        # Some formatting needs to be done so that the header row
+        # is compliant with the CSV dialect - all fields need
+        # to be quoted.
+        quoted_header_row = "\"{}\"".format("\",\"".join(view.header_row))
+        self.assertContains(response, quoted_header_row)
 
     def test_all_proposals_are_included(self):
         proposals = ProposalFactory.create_batch(size=randint(2, 4))


### PR DESCRIPTION
Change the dialect used when creating exported CSV files from the
default (`excel`) to `unix_dialect`. Since the latter quotes all fields
and uses Unix line endings, it is a better dialect.

This should also (hopefully) fix downloading issues on production. CSV
files with the `excel` dialect have Windows line endings. When an
exported CSV file is downloaded, the server changes these line endings
to Unix. This changes the size of the downloaded file and invalidates
the Content-Length HTTP header, which causes the download to fail over
HTTP/2.