### PR TITLE
Publish CFP page by default.

### DIFF
--- a/ansible/roles/web/templates/fixtures/pages.json
+++ b/ansible/roles/web/templates/fixtures/pages.json
@@ -146,8 +146,8 @@
         "title": "Call for Proposals",
         "slug": "cfp",
         "content_type": ["cms", "htmlpage"],
-        "live": false,
-        "has_unpublished_changes": true,
+        "live": true,
+        "has_unpublished_changes": false,
         "url_path": "/cfp/",
         "owner": 2,
         "seo_title": "",
@@ -157,7 +157,7 @@
         "expire_at": null,
         "expired": false,
         "locked": false,
-        "first_published_at": null,
+        "first_published_at": "2018-01-01T00:00:00Z",
         "latest_revision_created_at": "2018-01-01T00:00:00Z"
     }
 },


### PR DESCRIPTION
Ensure that the CFP page is published by default on newly deployed conference sites.