### PR TITLE
Remove "Submit to Moderation" button.

### DIFF
--- a/conf_site/core/apps.py
+++ b/conf_site/core/apps.py
@@ -5,3 +5,6 @@ from django.apps import AppConfig
 
 class CoreConfig(AppConfig):
     name = "core"
+
+    def ready(self):
+        import conf_site.core.wagtail_hooks              # noqa: F401

--- a/conf_site/core/wagtail_hooks.py
+++ b/conf_site/core/wagtail_hooks.py
@@ -1,0 +1,9 @@
+from wagtail.core import hooks
+
+
+@hooks.register("construct_page_action_menu")
+def remove_submit_to_moderator_option(menu_items, request, context):
+    # https://docs.wagtail.io/en/v2.6.2/reference/hooks.html#construct-page-action-menu
+    menu_items[:] = [
+        item for item in menu_items if item.name != "action-submit"
+    ]


### PR DESCRIPTION
Remove "Submit to Moderation" button from Wagtail's page editing interface.