### PR TITLE
Fix proposal notification warning message.

### DIFF
--- a/conf_site/reviews/models.py
+++ b/conf_site/reviews/models.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.contrib import messages
 from django.contrib.auth.models import User
 from django.core.mail import send_mass_mail
 from django.db import models
@@ -140,7 +139,9 @@ class ProposalNotification(models.Model):
         return "{}".format(self.subject)
 
     def send_email(self):
+        """Returns a list of speakers without email addresses."""
         email_messages = []
+        unemailed = []
         # Create a message for each email address.
         # This is necessary because we are not using BCC.
         for proposal in self.proposals.all():
@@ -161,11 +162,6 @@ class ProposalNotification(models.Model):
                     )
                     email_messages.append(datamessage_tuple)
                 else:
-                    messages.warning(
-                        "Speaker {} on proposal {} "
-                        "does not have an email address "
-                        "and has not been notified.".format(
-                            speaker.name, proposal.title
-                        )
-                    )
+                    unemailed.append(speaker)
         send_mass_mail(email_messages)
+        return unemailed

--- a/conf_site/reviews/views/results.py
+++ b/conf_site/reviews/views/results.py
@@ -105,7 +105,13 @@ class ProposalMultieditPostView(SuperuserOnlyView):
                 body=self.request.POST.get("body"),
             )
             notification.proposals.set(proposals)
-            notification.send_email()
+            unemailed_speakers = notification.send_email()
+            for speaker in unemailed_speakers:
+                messages.warning(
+                    self.request,
+                    "Speaker {} does not have an email address "
+                    "and has not been notified.".format(speaker.name)
+                )
             return HttpResponseRedirect(reverse("review_proposal_list"))
         elif self.request.POST.get("create_presentations"):
             num_presentations_created = 0


### PR DESCRIPTION
Fix warning message about speakers without email addresses shown when notifying proposal speakers.

Fix #404.