### PR TITLE
Fix missing Bronze sponsor benefits.

### DIFF
--- a/ansible/roles/web/templates/fixtures/sponsors.json
+++ b/ansible/roles/web/templates/fixtures/sponsors.json
@@ -215,5 +215,25 @@
     },
     "model": "symposion_sponsorship.benefitlevel",
     "pk": 19
+},
+{
+    "fields": {
+        "other_limits": "",
+        "benefit": 2,
+        "max_words": null,
+        "level": 7
+    },
+    "model": "symposion_sponsorship.benefitlevel",
+    "pk": 20
+},
+{
+    "fields": {
+        "other_limits": "",
+        "benefit": 4,
+        "max_words": null,
+        "level": 7
+    },
+    "model": "symposion_sponsorship.benefitlevel",
+    "pk": 21
 }
 ]


### PR DESCRIPTION
Add missing logo and description benefits back to Bronze level sponsors.