### PR TITLE
Constrain a presentation's additional speakers.

### DIFF
--- a/symposion/schedule/models.py
+++ b/symposion/schedule/models.py
@@ -283,7 +283,8 @@ class Presentation(models.Model):
         yield self.speaker
         accepted_status = AdditionalSpeaker.SPEAKING_STATUS_ACCEPTED
         speakers = self.additional_speakers.filter(
-            additionalspeaker__status=accepted_status
+            additionalspeaker__status=accepted_status,
+            additionalspeaker__proposalbase=self.proposal_base,
         )
         for speaker in speakers:
             yield speaker


### PR DESCRIPTION
Ensure that the `speakers()` generation method for Presentations ensures
that additional speakers are associated with this Presentation.

This eliminates an edge case where duplicated speakers would appear if
an individual was an "additional speaker" on multiple proposals.