### PR TITLE
Add actor context to proposal_detail view.

### DIFF
--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -264,7 +264,11 @@ def proposal_detail(request, pk):
     return render(
         request,
         "symposion/proposals/proposal_detail.html",
-        {"proposal": proposal, "feedback_form": feedback_form},
+        {
+            "proposal": proposal,
+            "feedback_form": feedback_form,
+            "actor": "speaker",
+        },
     )
 
 


### PR DESCRIPTION
Ensure that symposion `proposal_detail` view has the "actor" context variable used to determine whether usernames should be shown in blind reviewing situations.