### PR TITLE
Automatically insert conference title on homepage.

### DIFF
--- a/ansible/roles/web/templates/fixtures/pages.json
+++ b/ansible/roles/web/templates/fixtures/pages.json
@@ -30,7 +30,7 @@
     "fields": {
         "logo_image": null,
         "background_image": null,
-        "conference_info_section": "[{\"type\": \"rich_text\", \"value\": \"<div>\\r\\n<h1>{{ conference_name }}</h1>\\r\\n<h3>INSERT DATE 2018</h3>\\r\\n\\r\\n<h3>Have questions? Interested in sponsoring? Email us at <a href=\\\"mailto:admin@pydata.org\\\">admin@pydata.org</a>.</h3>\\r\\n</div>\"}]",
+        "conference_info_section": "[{\"type\": \"rich_text\", \"value\": \"<div>\\r\\n<h3>INSERT DATE 2020</h3>\\r\\n\\r\\n<h3>Have questions? Interested in sponsoring? Email us at <a href=\\\"mailto:admin@pydata.org\\\">admin@pydata.org</a>.</h3>\\r\\n</div>\"}]",
         "pydata_info_section": "[{\"type\": \"raw_html\", \"value\": \"<div class=\\\"col-xs-12 sec2\\\">\\r\\n<img src=\\\"./static/images/pydata-fullbocks.png\\\" data-rjs=\\\"2\\\" id=\\\"mono2\\\">\\r\\n<h2>WHAT IS</h2>\\r\\n<h1>PYDATA</h1>\\r\\n<p>PyData conferences bring together users and developers of data analysis tools to share ideas and learn from each other. The PyData community gathers to discuss how best to apply Python tools, as well as tools using R and Julia, to meet evolving challenges in data management, processing, analytics, and visualization.\\r\\n</p><p>\\r\\nWe aim to be an accessible, community-driven conference, with tutorials for novices, advanced topical workshops for practitioners, and opportunities for package developers and users to meet in person.\\r\\n</p><p>\\r\\nFor more information about the conference series, visit:</p>\\r\\n<p><a href=\\\"https://pydata.org\\\" class=\\\"btn btn1\\\">PyData.org</a></p>\\r\\n</div>\"}]",
         "news_keynote_section": "[]",
         "ticketing_section": "<h2>Tickets</h2>",

--- a/conf_site/templates/homepage.html
+++ b/conf_site/templates/homepage.html
@@ -15,6 +15,7 @@
         <div class="sec1x-elem sec1x-before"></div>
         <div class="container" id="sec1">
             <div class="col-xs-12 nopd sec1x">
+                <h1>{{ conference_title }}</h1>
                 {{ page.conference_info_section }}
             </div>
         </div>


### PR DESCRIPTION
  - Make h1 tag containing conference title part of the homepage's template. Since all conference sites use this same text, and `h1` tags are not editable by default in rich text blocks (see [^1]).
  - Remove title from default homepage fixture data to avoid duplication.

[^1]: https://docs.wagtail.io/en/v2.7.1/advanced_topics/customisation/rich_text_internals.html#rich-text-internals