### PR TITLE
Fix typo in ProposalResultListView URL.

### DIFF
--- a/conf_site/reviews/urls.py
+++ b/conf_site/reviews/urls.py
@@ -49,7 +49,7 @@ urlpatterns = [
         name="review_proposal_vote",
     ),
     path(
-        "reviews/result/<status>/",
+        "result/<status>/",
         ProposalResultListView.as_view(),
         name="review_proposal_result_list",
     ),


### PR DESCRIPTION
Fix duplicate "reviews" in ProposalResultListView URL so that URL is "/reviews/result/<status>/", not "/reviews/reviews/result/<status>".