### PR TITLE
Add red asterisk to form required fields.

### DIFF
--- a/conf_site/proposals/forms.py
+++ b/conf_site/proposals/forms.py
@@ -27,6 +27,8 @@ class ModelMultipleTagChoiceField(forms.ModelMultipleChoiceField):
 
 
 class ProposalForm(forms.ModelForm):
+    required_css_class = "formfield-required"
+
     official_keywords = ModelMultipleTagChoiceField(
         label="Official Keywords",
         queryset=ProposalKeyword.objects.filter(official=True).order_by("name"))    # noqa: E501

--- a/conf_site/static/css/mainstream-vc.css
+++ b/conf_site/static/css/mainstream-vc.css
@@ -800,6 +800,12 @@ img.right {
 	color: #007d8a;
 }
 
+label.formfield-required:after {
+    color: red;
+    content:" *";
+
+}
+
 @media (max-width: 1500px) {
   #sec1x-con .sec1-col, #nst-con .vcs { margin-left: 150px; }
 }

--- a/conf_site/templates/symposion/proposals/proposal_edit.html
+++ b/conf_site/templates/symposion/proposals/proposal_edit.html
@@ -13,6 +13,7 @@
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
         <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
             {{ form|bootstrap }}
         </fieldset>
         <div class="form-group form-actions">

--- a/conf_site/templates/symposion/proposals/proposal_submit_kind.html
+++ b/conf_site/templates/symposion/proposals/proposal_submit_kind.html
@@ -6,9 +6,11 @@
 
 {% block body %}
 <div class="container">
+    <h1>Submit a {{ kind.name }}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
         <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
             {{ proposal_form|bootstrap }}
         </fieldset>
         <div class="form-group form-actions">

--- a/conf_site/templates/symposion/speakers/speaker_create.html
+++ b/conf_site/templates/symposion/speakers/speaker_create.html
@@ -6,10 +6,11 @@
 
 {% block body %}
 <div class="container">
+    <h1>{% trans "Create Speaker Profile" %}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <legend>{% trans "Create Speaker Profile" %}</legend>
         <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
             {{ speaker_form|bootstrap }}
         </fieldset>
         <div class="form-actions">

--- a/conf_site/templates/symposion/speakers/speaker_edit.html
+++ b/conf_site/templates/symposion/speakers/speaker_edit.html
@@ -6,10 +6,11 @@
 
 {% block body %}
 <div class="container">
+    <h1>{% trans "Edit Speaker Profile" %}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <legend>{% trans "Edit Speaker Profile" %}</legend>
         <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
             {{ speaker_form|bootstrap }}
         </fieldset>
         <div class="form-actions">

--- a/conf_site/templates/symposion/sponsorship/add.html
+++ b/conf_site/templates/symposion/sponsorship/add.html
@@ -9,10 +9,13 @@
 
 {% block body %}
 <div class="container">
+    <h1>{% trans "Add a Sponsor" %}</h1>
     <form method="POST" action="{% url "sponsor_add" %}" class="form-horizontal">
         {% csrf_token %}
-        <legend>{% trans "Add a Sponsor" %}</legend>
-        {{ form|bootstrap_horizontal }}
+        <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
+            {{ form|bootstrap_horizontal }}
+        </fieldset>
         <div class="form-actions">
             <input class="btn btn-primary" type="submit" value="Add" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>

--- a/conf_site/templates/symposion/sponsorship/apply.html
+++ b/conf_site/templates/symposion/sponsorship/apply.html
@@ -9,12 +9,15 @@
 
 {% block body %}
 <div class="container">
+    <h1>{% trans "Apply to Be a Sponsor" %}</h1>
     <h3><a href="{{ settings.sponsorship.SponsorshipSettings.info_link }}">PyData Sponsor Levels and Benefits</a></h3>
 
     <form method="POST" action="" class="form-horizontal">
         {% csrf_token %}
-        <legend>{% trans "Apply to Be a Sponsor" %}</legend>
-        {{ form|bootstrap_horizontal }}
+        <fieldset>
+            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
+            {{ form|bootstrap_horizontal }}
+        </fieldset>
         <div class="form-actions">
             <input class="btn btn-primary" type="submit" value="Apply" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>

--- a/symposion/speakers/forms.py
+++ b/symposion/speakers/forms.py
@@ -5,6 +5,7 @@ from symposion.speakers.models import Speaker
 
 
 class SpeakerForm(forms.ModelForm):
+    required_css_class = "formfield-required"
 
     class Meta:
         model = Speaker

--- a/symposion/sponsorship/forms.py
+++ b/symposion/sponsorship/forms.py
@@ -9,6 +9,8 @@ from symposion.sponsorship.models import Sponsor, SponsorBenefit
 
 
 class SponsorApplicationForm(forms.ModelForm):
+    required_css_class = "formfield-required"
+
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user")
         kwargs.update(


### PR DESCRIPTION
Add a red asterisk to show required fields on the forms for creating/editing proposals, speaker profiles, and sponsors.

This commit also makes some stylistic changes to forms (e.g. ensuring titles are in a `h1`, moving form `legends` into a `fieldset`, etc.).