### PR TITLE
Don't install Python 2 or aptitude.

### DIFF
--- a/ansible/tasks/bootstrap.yml
+++ b/ansible/tasks/bootstrap.yml
@@ -4,18 +4,6 @@
 # to be as root without sudo, they should live in roles/common/tasks
 # or somewhere else that's not here.
 # See https://gist.github.com/gwillem/4ba393dceb55e5ae276a87300f6b8e6f.
-- name: install Python 2 if needed
-  raw: test -e /usr/bin/python2 || (apt install -y python-minimal)
-  become: true
-  register: output
-  changed_when: output.stdout
-
-- name: install aptitude if needed
-  raw: test -e /usr/bin/aptitude || (apt install -y aptitude)
-  become: true
-  register: output
-  changed_when: output.stdout
-
 - name: ensure that we can login to deployment user account
   copy:
     dest: /home/{{ deployment_user }}/.ssh/authorized_keys


### PR DESCRIPTION
These bootstrapping tasks stopped being necessary when we switched from Ubuntu to Debian (see #132).