### PR TITLE
Improve display of ProposalSections in admin.

### DIFF
--- a/symposion/proposals/admin.py
+++ b/symposion/proposals/admin.py
@@ -3,5 +3,16 @@ from django.contrib import admin
 from symposion.proposals.models import ProposalSection, ProposalKind
 
 
-admin.site.register(ProposalSection)
+class ProposalSectionAdmin(admin.ModelAdmin):
+    list_display = [
+        "section",
+        "start",
+        "end",
+        "closed",
+        "published",
+        "is_available",
+    ]
+
+
+admin.site.register(ProposalSection, ProposalSectionAdmin)
 admin.site.register(ProposalKind)

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -60,6 +60,9 @@ class ProposalSection(models.Model):
             return False
         return True
 
+    is_available.boolean = True
+    is_available.short_description = "availability"
+
     def __str__(self):
         return self.section.name
 


### PR DESCRIPTION
Display ProposalSection's attributes, including its availability, in the list page in the Django admin for the model. This makes it easier to determine whether a ProposalSection is accepting new submissions / allowing editing.