### PR TITLE
Add default proposal form.

### DIFF
--- a/conf_site/proposals/tests/test_editing_proposals.py
+++ b/conf_site/proposals/tests/test_editing_proposals.py
@@ -19,14 +19,9 @@ class ProposalEditingViewTestCase(ProposalSpeakerTestCase):
 
     def _proposal_edit_response(self):
         """Helper method to get response from `proposal_edit` view."""
-        proposal_kind_slug = self.proposal.kind.slug
-        proposal_forms = {
-            proposal_kind_slug: "conf_site.proposals.forms.ProposalForm"
-        }
-        with self.settings(PROPOSAL_FORMS=proposal_forms):
-            return self.client.get(
-                reverse("proposal_edit", args=[self.proposal.pk])
-            )
+        return self.client.get(
+            reverse("proposal_edit", args=[self.proposal.pk])
+        )
 
     @override_config(PROPOSAL_EDITING_WHEN_CFP_IS_CLOSED=True)
     def test_ability_to_edit_if_setting_is_disabled(self):

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -280,6 +280,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
     "Reviewing Options": ("BLIND_AUTHORS", "BLIND_REVIEWERS"),
 }
 CSRF_FAILURE_VIEW = "conf_site.core.views.csrf_failure"
+DEFAULT_PROPOSAL_FORM = "conf_site.proposals.forms.ProposalForm"
 LOGIN_REDIRECT_URL = "dashboard"
 PROPOSAL_FORMS = {
     "talk": "conf_site.proposals.forms.ProposalForm",

--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -95,7 +95,10 @@ def proposal_submit_kind(request, kind_slug):
     if not kind.section.proposalsection.is_available():
         return redirect("proposal_submit")
 
-    form_class = get_form(settings.PROPOSAL_FORMS[kind_slug])
+    try:
+        form_class = get_form(settings.PROPOSAL_FORMS[kind_slug])
+    except KeyError:
+        form_class = get_form(settings.DEFAULT_PROPOSAL_FORM)
 
     if request.method == "POST":
         form = form_class(request.POST)
@@ -223,7 +226,10 @@ def proposal_edit(request, pk):
         }
         return render(request, "symposion/proposals/proposal_error.html", ctx)
 
-    form_class = get_form(settings.PROPOSAL_FORMS[proposal.kind.slug])
+    try:
+        form_class = get_form(settings.PROPOSAL_FORMS[proposal.kind.slug])
+    except KeyError:
+        form_class = get_form(settings.DEFAULT_PROPOSAL_FORM)
 
     if request.method == "POST":
         form = form_class(request.POST, instance=proposal)


### PR DESCRIPTION
  - Create new `DEFAULT_PROPOSAL_FORM `setting that is used if ProposalKind does not match an entry in `PROPOSAL_FORMS`.
  - Update proposal editing tests to stop overriding `PROPOSAL_FORMS` so we can achieve partial test coverage with our existing tests.