### PR TITLE
Add email addresses to ExportProposalsView CSV.

### DIFF
--- a/conf_site/proposals/views.py
+++ b/conf_site/proposals/views.py
@@ -40,7 +40,9 @@ class ExportProposalsView(CsvView):
     header_row = [
         "Number",
         "Title",
-        "Primary Speaker",
+        "Primary Speaker Name",
+        "Primary Speaker Email",
+        "All Speaker Email Addresses",
         "Kind",
         "Audience Level",
         "Date Created",
@@ -50,11 +52,16 @@ class ExportProposalsView(CsvView):
     def get(self, *args, **kwargs):
         # Iterate through proposals.
         for proposal in Proposal.objects.order_by("pk"):
+            accepted_speaker_email_addresses = ", ".join(
+                speaker.email for speaker in proposal.speakers()
+            )
             self.csv_writer.writerow(
                 [
                     proposal.number,
                     proposal.title,
                     proposal.speaker.name,
+                    proposal.speaker.email,
+                    accepted_speaker_email_addresses,
                     proposal.kind.name,
                     proposal.get_audience_level_display(),
                     proposal.date_created,


### PR DESCRIPTION
Add two additional fields to the CSV of exported proposals to export the email addresses of the primary speaker and of all accepted proposal speakers.