### PR TITLE
Change proposal title shown to submitters.

### DIFF
--- a/conf_site/templates/symposion/proposals/proposal_detail.html
+++ b/conf_site/templates/symposion/proposals/proposal_detail.html
@@ -27,7 +27,11 @@
         {% endif %}
     </div>
 
-    <h3>#{{ proposal.number }}: {{ proposal.title }} ({{ proposal.speaker.name }}, Track: {{ proposal.track }})</h3>
+    {% if request.user == proposal.speaker.user %}
+    <h3>{{ proposal.title }}</h3>
+    {% else %}
+    <h3>#{{ proposal.number }}: {{ proposal.title }} ({{ proposal.speaker.name }})</h3>
+    {% endif %}
 
     <div class="tabbable">
         <ul class="nav nav-tabs">


### PR DESCRIPTION
Change proposal title shown to submitters on the proposal detail page. Proposal submitters do not need to see the proposal number (irrelevant), their name (obvious), or their track (which doesn't exist).