### PR TITLE
Move Ansible variables to decrease precedence.

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -2,7 +2,10 @@ admin_email: admin@pydata.org
 amy_username: amy
 ansible_python_interpreter: /usr/bin/python3
 application_owner: mobolic
+cloudflare_enabled: true
 database_host: localhost
+default_email: noreply@pydata.org
+email_host_user: noreply@pydata.org
 git_version: master
 gunicorn_port: 10501
 project_root: "/srv/pydata"

--- a/ansible/group_vars/production
+++ b/ansible/group_vars/production
@@ -1,4 +1,1 @@
-cloudflare_enabled: true
-default_email: noreply@pydata.org
-email_host_user: noreply@pydata.org
 environment_type: production


### PR DESCRIPTION
Move non-essential Ansible variables from "production" group to "all" to decrease their precedence. Previously, these group variables were overriding variables in host_vars.