### PR TITLE
Simplify first submission heading more

### DIFF
--- a/conf_site/proposals/forms.py
+++ b/conf_site/proposals/forms.py
@@ -9,7 +9,7 @@ from conf_site.proposals.models import Proposal
 
 SECTION1_LEGEND = (
     "<h4>The following information will be listed publicly "
-    "in the conference program for a {{ kind.name|lower }}.</h4>"
+    "in the conference program.</h4>"
 )
 
 


### PR DESCRIPTION
The title just above the header already has the submission kind (see pic below), and the way we have some submissions like “talk: track name”, it sort of looks weird in a sentence.

<img width="1319" alt="Screen Shot 2020-03-17 at 8 34 08 PM" src="https://user-images.githubusercontent.com/192614/76922907-3ced0600-688f-11ea-80e6-2c2b7cbd889d.png">