### PR TITLE
Remove LetsEncrypt certbot cronjob.

### DIFF
--- a/ansible/roles/web/tasks/letsencrypt.yml
+++ b/ansible/roles/web/tasks/letsencrypt.yml
@@ -24,12 +24,3 @@
     creates: /etc/letsencrypt/live/{{ website_domain }}/fullchain.pem
   become: true
   when: not cloudflare_enabled and environment_type != "development"
-
-- name: use cronjob to periodically renew certificates
-  cron: >
-    name="renew SSL certificates"
-    job='certbot renew -nq --pre-hook "service nginx stop" --post-hook "service nginx start"'
-    hour=07
-    minute=35
-  become: true
-  when: not cloudflare_enabled


### PR DESCRIPTION
This list of Ansible tasks was originally created for Debian 8 (Jessie) servers, which did not include certbot as a package. Since we now install certbot through Debian, including a separate cron job is
superfluous and wasteful.