### PR TITLE
Remove beautifulsoup4 dependency.

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,7 +1,6 @@
 -r staging.txt
 ansible==2.9.3
 ansible-lint==4.2.0
-beautifulsoup4==4.6.0
 coverage==5.0.3
 factory_boy==2.12.0
 flake8==3.7.9


### PR DESCRIPTION
Remove beautifulsoup as a hardcoded dependency. We were using it to parse HTML in a test that was removed in #353.