### PR TITLE
Add ability to filter proposals by kind.

### DIFF
--- a/conf_site/reviews/tests/test_proposal_kind_list_view.py
+++ b/conf_site/reviews/tests/test_proposal_kind_list_view.py
@@ -1,0 +1,55 @@
+from random import randint
+
+from django.urls import reverse
+
+from faker import Faker
+
+from conf_site.accounts.tests import AccountsTestCase
+from conf_site.proposals.tests.factories import (
+    ProposalFactory,
+    ProposalKindFactory,
+)
+from conf_site.reviews.tests import ReviewingTestCase
+
+
+class ProposalKindListViewTestCase(ReviewingTestCase, AccountsTestCase):
+    reverse_view_name = "review_proposal_kind_list"
+
+    def setUp(self):
+        super().setUp()
+        self.faker = Faker()
+
+        self.proposal_kind = ProposalKindFactory.create()
+        self.reverse_view_args = [self.proposal_kind.slug]
+
+    # Disable reviewing methods that are not valid for this view
+    # because it contains a subset of all proposals.
+    def test_blind_reviewing_types_as_reviewer(self):
+        pass
+
+    def test_blind_reviewers_as_superuser(self):
+        pass
+
+    def test_invalid_kind(self):
+        """Verify that a random kind returns a 404."""
+        self._add_to_reviewers_group()
+        response = self.client.get(
+            reverse(self.reverse_view_name, args=[self.faker.word()])
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_correct_information(self):
+        """Verify that shown proposals are correct."""
+        self._add_to_reviewers_group()
+        shown_proposals = ProposalFactory.create_batch(
+            size=randint(5, 10), kind=self.proposal_kind
+        )
+        unshown_proposals = ProposalFactory.create_batch(size=randint(5, 10))
+
+        response = self.client.get(
+            reverse(self.reverse_view_name, args=self.reverse_view_args)
+        )
+        for proposal in shown_proposals:
+            self.assertContains(response, proposal.title)
+        for proposal in unshown_proposals:
+            self.assertNotContains(response, proposal.title)

--- a/conf_site/reviews/urls.py
+++ b/conf_site/reviews/urls.py
@@ -4,6 +4,7 @@ from django.urls import path
 from conf_site.reviews.views import (
     ProposalDetailView,
     ProposalFeedbackPostView,
+    ProposalKindListView,
     ProposalListView,
     ProposalVotePostView,
 )
@@ -29,6 +30,11 @@ urlpatterns = [
         "keyword/<slug:keyword_slug>/",
         ReviewKeywordDetailView.as_view(),
         name="review_keyword_detail",
+    ),
+    path(
+        "kind/<kind>/",
+        ProposalKindListView.as_view(),
+        name="review_proposal_kind_list",
     ),
     path(
         "proposal/<int:pk>/",

--- a/conf_site/templates/reviews/_proposal_mini_navigation.html
+++ b/conf_site/templates/reviews/_proposal_mini_navigation.html
@@ -9,4 +9,7 @@
   <li><a href="{% url 'review_proposal_result_list' 'S' %}">Standby Proposals</a></li>
   <li><a href="{% url 'review_proposal_result_list' 'U' %}">Undecided Proposals</a></li>
 {% endif %}
+{% for kind in kind_list %}
+  <li><a href="{% url 'review_proposal_kind_list' kind.slug %}">All {{ kind.name }}s</a></li>
+{% endfor %}
 </ul>

--- a/conf_site/templates/reviews/proposal_list.html
+++ b/conf_site/templates/reviews/proposal_list.html
@@ -2,12 +2,12 @@
 {% load crispy_forms_tags i18n review_tags %}
 {% load static %}
 
-{% block title %} - Reviewing {{ proposal_category }} Proposals{% endblock %}
+{% block title %} - Reviewing {{ proposal_category }} {{ proposal_kind }}s{% endblock %}
 
 {% block body %}
 <div class="container">
   {% include "reviews/_proposal_mini_navigation.html" %}
-  <h2>{% block page-title %}{{ proposal_category }} Proposals{% endblock %}</h2>
+  <h2>{% block page-title %}{{ proposal_category }} {{ proposal_kind }}s{% endblock %}</h2>
   {% if config.BLIND_REVIEWERS and request.user.is_superuser %}
     <p class="bg-info">
       Your superuser status is ignoring the enabled


### PR DESCRIPTION
  - Add new proposal list view that filters proposals by kind.
  - Update reviewing navigation bar to automatically include links to all conference site ProposalKinds.
  - Update list page titles to avoid hardcoded references to "Proposals".