### PR TITLE
Remove release and phone number information.

### DIFF
--- a/conf_site/templates/symposion/proposals/_proposal_fields.html
+++ b/conf_site/templates/symposion/proposals/_proposal_fields.html
@@ -85,11 +85,13 @@
     <dd>{{ proposal.accomodation_needs }}&nbsp;</dd>
     {% endif %}
 
+    {% if request.user == proposal.speaker.user or request.user.is_superuser %}
     <hr>
     <dt>Recording Release</dt>
     <dd>{{ proposal.recording_release }}&nbsp;</dd>
     <dt>Phone Number</dt>
     <dd>{{ proposal.phone_number }}&nbsp;</dd>
+    {% endif %}
 
     {% if not config.BLIND_REVIEWERS or request.user.is_superuser %}
     <dt>{% trans "Speaker Bio" %}</dt>


### PR DESCRIPTION
Prevent reviewers who are not superusers from seeing speakers' recording releases and phone numbers.