### PR TITLE
Fix broken styling on "Send Email" button.

### DIFF
--- a/conf_site/templates/reviews/proposal_list.html
+++ b/conf_site/templates/reviews/proposal_list.html
@@ -85,7 +85,7 @@
     <p><em>This will send an email message to all selected proposals.</em></p>
     {{ notification_form|crispy }}
     <div class="btn-group" role="group" style="margin-bottom: 1rem">
-      <button type="submit" class="btn btn-standard" name="send_notification" value="EHLO">
+      <button type="submit" class="btn btn-primary" name="send_notification" value="EHLO">
         <i class="fa fa-envelope" aria-hidden="true"></i> Send Email Message
       </button>
     </div>


### PR DESCRIPTION
Use primary button styling on the reviewing section's "Send Email Message" button instead of (non-existent) "btn-standard" styling.