### PR TITLE
Prefer reviewer names over usernames.

### DIFF
--- a/conf_site/templates/reviews/_proposal_feedback_tab.html
+++ b/conf_site/templates/reviews/_proposal_feedback_tab.html
@@ -6,7 +6,7 @@
       {% elif not request.user.is_superuser and config.BLIND_REVIEWERS and actor == "reviewer" and feedback.author != request.user %}
         <b>Anonymous</b>
       {% else %}
-        <b>{{ feedback.author.username }}</b>:
+        <b>{{ feedback.author.get_full_name|default:feedback.author.username }}</b>:
       {% endif %}
       {{ feedback.comment_html|safe }}
     {% endfor %}

--- a/conf_site/templates/reviews/proposal_detail.html
+++ b/conf_site/templates/reviews/proposal_detail.html
@@ -76,7 +76,7 @@
           {% if not request.user.is_superuser and config.BLIND_REVIEWERS and review_vote.voter != request.user %}
             Anonymous
           {% else %}
-            {{ review_vote.voter.username }}
+            {{ review_vote.voter.get_full_name|default:review_vote.voter.username }}
           {% endif %}
           ({{ review_vote.get_score_display }})
         </h4>


### PR DESCRIPTION
Prefer displaying a reviewer's full name over their username in non-anonymous parts of the reviewing system.