### PR TITLE
Fix how number of talks are determined.

### DIFF
--- a/conf_site/reviews/views/__init__.py
+++ b/conf_site/reviews/views/__init__.py
@@ -73,7 +73,7 @@ class ProposalListView(ListView, ReviewingView):
             self.get_queryset().filter(kind__slug="poster").count()
         )
         context["num_talks"] = (
-            self.get_queryset().filter(kind__name__startswith="Talk").count()
+            self.get_queryset().filter(kind__name__endswith="Talk").count()
         )
         context["num_tutorials"] = (
             self.get_queryset().filter(kind__slug="tutorial").count()


### PR DESCRIPTION
Change how number of talks are determined since names of Talk categories have changed (they now *end* with "Talk" instead of beginning with it).