### PR TITLE
Prevent users from submitting empty votes.

### DIFF
--- a/conf_site/reviews/forms.py
+++ b/conf_site/reviews/forms.py
@@ -20,7 +20,7 @@ class ProposalVoteForm(forms.ModelForm):
             choices=ProposalVote.SCORES,
             coerce=int,
             empty_value=0,
-            widget=forms.RadioSelect(),
+            widget=forms.RadioSelect(attrs={"required": "required"}),
         )
 
 


### PR DESCRIPTION
We use ProposalVote objects with empty votes to mark them for reviewers. Prevent users from accidentally (or on purpose) converting additional votes into this state by updating ProposalVoteForm to not allow empty votes.