### PR TITLE
Add slug to invited speakers.

### DIFF
--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -145,7 +145,9 @@ def proposal_speaker_manage(request, pk):
                 except Speaker.DoesNotExist:
                     token = get_random_string(5)
                     pending = Speaker.objects.create(
-                        invite_email=email_address, invite_token=token
+                        invite_email=email_address,
+                        invite_token=token,
+                        slug=email_address.split("@")[0],
                     )
                 else:
                     token = pending.invite_token


### PR DESCRIPTION
Ensure that invited speakers are created with a slug based on their email address, since their name (which the slug would normally be automatically populated from) will be blank.