### PR TITLE
Remove bad logic from pending proposal template.

### DIFF
--- a/conf_site/templates/symposion/proposals/_pending_proposal_row.html
+++ b/conf_site/templates/symposion/proposals/_pending_proposal_row.html
@@ -11,15 +11,7 @@
         {% if proposal.cancelled %}
             <span class="label label-danger">{% trans 'Cancelled' %}</span>
         {% else %}
-            {% if request.user == proposal.speaker.user %}
-                {% if proposal.result.status == "accepted" %}
-                    <span class="label label-success">{% trans 'Accepted' %}</span>
-                {% else %}
-                    <span class="label label-default">{% trans 'Submitted' %}</span>
-                {% endif %}
-            {% else %}
-                <span class="label label-default">{% trans 'Invited' %}</span>
-            {% endif %}
+            <span class="label label-default">{% trans 'Invited' %}</span>
         {% endif %}
     </td>
 


### PR DESCRIPTION
Remove bad logic from pending proposal row template. Since this template is only used when a speaker is invited to a proposal, the current user will never be the main speaker on the proposal, so it is not necessary to check the proposal's status.