### PR TITLE
Add proposal number to proposal page and form emails

### DIFF
--- a/conf_site/templates/symposion/proposals/_proposal_fields.html
+++ b/conf_site/templates/symposion/proposals/_proposal_fields.html
@@ -1,6 +1,8 @@
 {% load i18n %}
 
 <dl class="dl-horizontal">
+    <dt>Proposal Number</dt>
+    <dd>{{ proposal.number }}</dd>
     <dt>{% trans "Category" %}</dt>
     <dd>{{ proposal.kind.name }}</dd>
     {% if not config.BLIND_REVIEWERS or request.user.is_superuser %}

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -197,6 +197,7 @@ class ProposalBase(models.Model):
     def notification_email_context(self):
         return {
             "title": self.title,
+            "number": self.number,
             "speaker": self.speaker.name,
             "speakers": ", ".join([x.name for x in self.speakers()]),
             "kind": self.kind.name,


### PR DESCRIPTION
We plan to tell speakers to submit files using the proposal number as a short unique identifier. To do this, we need be able to tell them their proposal number. This puts it on the proposal page and available as a field in the form emails.