### PR TITLE
Schedule CSS changes for JupyterCon.

### DIFF
--- a/conf_site/static/css/jupytercon.css
+++ b/conf_site/static/css/jupytercon.css
@@ -66,6 +66,7 @@ h6 {
 }
 
 p {
+    color: #0a0a0a;
     font-size: 16px;
     letter-spacing: normal;
     line-height: 1.6;

--- a/conf_site/static/css/jupytercon.css
+++ b/conf_site/static/css/jupytercon.css
@@ -3,6 +3,10 @@
     src: url('../fonts/GoshaSans-Regular.otf') format('opentype');
 }
 
+html {
+    font-size: 100%;
+}
+
 body {
     margin: 0;
     padding: 0;

--- a/conf_site/templates/symposion/schedule/presentation_detail.html
+++ b/conf_site/templates/symposion/schedule/presentation_detail.html
@@ -16,7 +16,7 @@
     {% if request.user.is_staff %}
         <a class="btn btn-default pull-right" href="{% url 'admin:symposion_schedule_presentation_change' presentation.id %}">Edit</a>
     {% endif %}
-    <h2>{{ presentation.title }}</h2>
+    <h1>{{ presentation.title }}</h1>
 
     <h4>{% for speaker in presentation.speakers %}{% if speaker.name %}{% if not forloop.first %}, {% endif %}<a href="{% url "speaker_profile" speaker.pk speaker.slug %}">{{ speaker }}</a>{% endif %}{% endfor %}</h4>
     <dl class="dl-horizontal">


### PR DESCRIPTION
  - Fix overly-grey paragraphs.
  - Make headings smaller and more consistent with main JupyterCon site.
  - Ensure that presentation detail pages use h1 element.