### PR TITLE
Remove SlotRoomInline from RoomAdmin.

### DIFF
--- a/symposion/schedule/admin.py
+++ b/symposion/schedule/admin.py
@@ -40,7 +40,6 @@ class SlotAdmin(admin.ModelAdmin):
 class RoomAdmin(admin.ModelAdmin):
     list_display = ["name", "order", "schedule"]
     list_filter = ["schedule"]
-    inlines = [SlotRoomInline]
 
 
 class PresentationAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Remove inline containing slots from RoomAdmin. This will avoid gateway timeouts when editing rooms that are associated with several slots.