### PR TITLE
Stop secondary speakers from leaving proposals.

### DIFF
--- a/conf_site/templates/symposion/proposals/proposal_detail.html
+++ b/conf_site/templates/symposion/proposals/proposal_detail.html
@@ -17,10 +17,6 @@
                 <a href="{% url "proposal_cancel" proposal.pk %}" class="btn btn-default">
                     {% trans "Cancel this proposal" %}
                 </a>
-            {% else %}
-                <a href="{% url "proposal_leave" proposal.pk %}" class="btn btn-default">
-                    {% trans "Remove me from this proposal" %}
-                </a>
             {% endif %}
         {% else %}
             {% trans 'Cancelled' }

--- a/symposion/proposals/urls.py
+++ b/symposion/proposals/urls.py
@@ -7,7 +7,6 @@ from .views import (
     proposal_edit,
     proposal_speaker_manage,
     proposal_cancel,
-    proposal_leave,
     proposal_pending_join,
     proposal_pending_decline,
     document_create,
@@ -30,7 +29,6 @@ urlpatterns = [
         name="proposal_speaker_manage",
     ),
     url(r"^(\d+)/cancel/$", proposal_cancel, name="proposal_cancel"),
-    url(r"^(\d+)/leave/$", proposal_leave, name="proposal_leave"),
     url(r"^(\d+)/join/$", proposal_pending_join, name="proposal_pending_join"),
     url(
         r"^(\d+)/decline/$",

--- a/symposion/proposals/views.py
+++ b/symposion/proposals/views.py
@@ -303,30 +303,6 @@ def proposal_cancel(request, pk):
 
 
 @login_required
-def proposal_leave(request, pk):
-    queryset = ProposalBase.objects.select_related("speaker")
-    proposal = get_object_or_404(queryset, pk=pk)
-    proposal = ProposalBase.objects.get_subclass(pk=proposal.pk)
-
-    try:
-        speaker = proposal.additional_speakers.get(user=request.user)
-    except ObjectDoesNotExist:
-        return HttpResponseForbidden()
-    if request.method == "POST":
-        # The AdditionalSpeaker object requires a Speaker and a ProposalBase,
-        # so the only way to "remove" it from the proposal is through
-        # deletion.
-        speaker.delete()
-        # @@@ fire off email to submitter and other speakers
-        messages.success(
-            request, "You are no longer speaking on %s" % proposal.title
-        )
-        return redirect("dashboard")
-    ctx = {"proposal": proposal}
-    return render(request, "symposion/proposals/proposal_leave.html", ctx)
-
-
-@login_required
 def proposal_pending_join(request, pk):
     proposal = get_object_or_404(ProposalBase, pk=pk)
     speaking = get_object_or_404(


### PR DESCRIPTION
Temporarily fix bug that caused secondary speakers who left a proposal to delete their speaker profile (and all associated proposals, reviews, and presentations) by removing ability to leave proposals completely.

See #294.