### PR TITLE
Remove cancelled presentations.

### DIFF
--- a/conf_site/schedule/tests/test_export_presentation_speakers.py
+++ b/conf_site/schedule/tests/test_export_presentation_speakers.py
@@ -1,7 +1,18 @@
+from django.urls import reverse
+
 from conf_site.core.tests.test_csv_view import StaffOnlyCsvViewTestCase
+from conf_site.schedule.tests.factories import PresentationFactory
 from conf_site.schedule.views import ExportPresentationSpeakerView
 
 
 class ExportPresentationSpeakerViewTestCase(StaffOnlyCsvViewTestCase):
     view_class = ExportPresentationSpeakerView
     view_name = "presentation_speaker_export"
+
+    def test_cancelled_presentations_do_not_appear(self):
+        self._become_staff()
+        self.client.login(username=self.user.email, password=self.password)
+
+        cancelled_presentation = PresentationFactory(cancelled=True)
+        response = self.client.get(reverse(self.view_name))
+        self.assertNotContains(response, cancelled_presentation.title)

--- a/conf_site/schedule/tests/test_schedule_presentation_detail.py
+++ b/conf_site/schedule/tests/test_schedule_presentation_detail.py
@@ -94,3 +94,10 @@ class SchedulePresentationDetailViewTestCase(PresentationTestCase):
         self._staff_login()
         response = self.client.get(self.presentation_url)
         self.assertContains(response, admin_edit_url)
+
+    def test_cancelled_presentation(self):
+        """Verify that pages do not work if presentation is cancelled."""
+        self.presentation.cancelled = True
+        self.presentation.save()
+        response = self.client.get(self.presentation_url)
+        self.assertEqual(response.status_code, 404)

--- a/conf_site/speakers/tests/test_speaker_list.py
+++ b/conf_site/speakers/tests/test_speaker_list.py
@@ -174,3 +174,9 @@ class SpeakerListViewTestCase(AccountsTestCase):
             "speaker_profile", args=[speaker2.pk, speaker2.slug]
         )
         self.assertNotContains(response, speaker2_url)
+
+    def test_cancelled_presentations(self):
+        """Verify that cancelled presentations do not appear."""
+        presentation = PresentationFactory(cancelled=True)
+        response = self.client.get(reverse("speaker_list"))
+        self.assertNotContains(response, presentation.title)

--- a/conf_site/templates/speakers/speaker_list.html
+++ b/conf_site/templates/speakers/speaker_list.html
@@ -15,7 +15,7 @@
     <tbody>
       {% for speaker in speakers %}{% if speaker.name %}<tr>
         <td><a href="{% url 'speaker_profile' speaker.pk speaker.slug %}">{{ speaker.name }}</a></td>
-        <td>{% for presentation in speaker.all_presentations %}
+        <td>{% for presentation in speaker.not_cancelled_presentations %}
           <a href="{% url 'schedule_presentation_detail' presentation.pk presentation.slug %}">
             {{ presentation.title }}</a>{% if not forloop.last %}, {% endif %}
         {% endfor %}</td>

--- a/symposion/speakers/models.py
+++ b/symposion/speakers/models.py
@@ -115,3 +115,14 @@ class Speaker(models.Model):
             for p in self.copresentations.all():
                 presentations.append(p)
         return presentations
+
+    @property
+    def not_cancelled_presentations(self):
+        """Property containing non-cancelled presentations."""
+        presentations = []
+        if self.presentations:
+            for p in self.presentations.exclude(cancelled=True):
+                presentations.append(p)
+            for p in self.copresentations.exclude(cancelled=True):
+                presentations.append(p)
+        return presentations


### PR DESCRIPTION
  - Create new "not_cancelled_presentations" method for Speakers to more easily access their presentations that have not been cancelled.
  - Do not show cancelled presentations in presentation speaker or schedule CSV exports.
  - Wish that this codebase used the American "canceled" and not the British "cancelled".

Fix #706.