### PR TITLE
Speaker page display changes.

### DIFF
--- a/conf_site/speakers/tests/test_speaker_profile.py
+++ b/conf_site/speakers/tests/test_speaker_profile.py
@@ -120,6 +120,18 @@ class SpeakerProfileTestCase(TestCase):
         self.assertContains(response, FIRST_PRESENTATION_TITLE)
         self.assertNotContains(response, SECOND_PRESENTATION_TITLE)
 
+    def test_do_not_display_if_schedule_is_not_published(self):
+        for schedule in Schedule.objects.all():
+            schedule.published = False
+            schedule.save()
+
+        response = self.client.get(
+            reverse(
+                "speaker_profile", args=[self.speaker.pk, self.speaker.slug]
+            )
+        )
+        self.assertEqual(response.status_code, 404)
+
     def test_second_speaker_profile_page(self):
         """Verify that a second speaker's profile page is public."""
         second_speaker = Speaker.objects.create(name="Nancy Pelosi")

--- a/conf_site/speakers/tests/test_speaker_profile.py
+++ b/conf_site/speakers/tests/test_speaker_profile.py
@@ -96,8 +96,20 @@ class SpeakerProfileTestCase(TestCase):
         self.assertContains(response, FIRST_PRESENTATION_TITLE)
         self.assertContains(response, SECOND_PRESENTATION_TITLE)
 
-    def test_do_not_display_unscheduled_presentations(self):
+    def test_display_unscheduled_presentations(self):
         self.second_presentation.slot = None
+        self.second_presentation.save()
+
+        response = self.client.get(
+            reverse(
+                "speaker_profile", args=[self.speaker.pk, self.speaker.slug]
+            )
+        )
+        self.assertContains(response, FIRST_PRESENTATION_TITLE)
+        self.assertContains(response, SECOND_PRESENTATION_TITLE)
+
+    def test_do_not_display_cancelled_presentations(self):
+        self.second_presentation.cancelled = True
         self.second_presentation.save()
 
         response = self.client.get(

--- a/conf_site/speakers/views.py
+++ b/conf_site/speakers/views.py
@@ -18,9 +18,7 @@ class SpeakerDetailView(SlugDetailView):
     def _get_presentations(self):
         """Utility method to retrive a speaker's presentations."""
         speaker = self.get_object()
-        return list(speaker.presentations.exclude(slot=None)) + list(
-            speaker.copresentations.exclude(slot=None)
-        )
+        return speaker.not_cancelled_presentations
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/conf_site/speakers/views.py
+++ b/conf_site/speakers/views.py
@@ -37,6 +37,17 @@ class SpeakerDetailView(SlugDetailView):
         if not presentations and not self.request.user.is_staff:
             raise Http404()
 
+        # Make sure that at least one presentation is on a published schedule.
+        for presentation in presentations:
+            try:
+                schedule = Schedule.objects.get(section=presentation.section)
+            except Schedule.DoesNotExist:
+                continue
+            if schedule.published:
+                break
+        else:
+            raise Http404()
+
         return super().render_to_response(context, **response_kwargs)
 
 


### PR DESCRIPTION
  - Expand speaker profile pages so that they appear for speakers with presentations not attached to schedule slots.
  - Restrict speaker profile pages so that they do not appear if the speaker does not have at least one presentation in a published schedule. This avoids disclosing speakers and presentations from yet-to-be published schedules.