### PR TITLE
Make not using a subdirectory optional in dev.

### DIFF
--- a/ansible/group_vars/development
+++ b/ansible/group_vars/development
@@ -7,7 +7,7 @@ django_database: "{{ conference_identifier }}"
 email_host_user: example@example.com
 environment_type: development
 google_analytics_id: UA-00000-0
-subdirectory: /{{ conference_identifier }}
+subdirectory: ""
 time_format: P
 timezone: US/Eastern
 website_domain: localhost


### PR DESCRIPTION
Change default behavior of local development environments to not use subfolders/subdirectories. The default site homepage will now be http://localhost:8080/, not http://localhost:8080/test/.