### PR TITLE
Remove red asterisk instructions.

### DIFF
--- a/conf_site/templates/base.html
+++ b/conf_site/templates/base.html
@@ -221,10 +221,6 @@
         }
         .btn.btn-danger:hover {
             background-color: #ac2925;
-        label.formfield-required:after {
-            color: red;
-            content:" *";
-        }
     </style>
 
     {% block extra_head %}{% endblock %}

--- a/conf_site/templates/symposion/proposals/proposal_edit.html
+++ b/conf_site/templates/symposion/proposals/proposal_edit.html
@@ -12,10 +12,7 @@
 
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {{ form|crispy }}
-        </fieldset>
+        {{ form|crispy }}
         <div class="form-group form-actions">
             <input class="btn btn-base-color" type="submit" value="Save" />
             <a class="btn btn-default" href="{% url "proposal_detail" proposal.pk %}">Cancel</a>

--- a/conf_site/templates/symposion/proposals/proposal_submit_kind.html
+++ b/conf_site/templates/symposion/proposals/proposal_submit_kind.html
@@ -9,10 +9,7 @@
     <h1>Submit a {{ kind.name }}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {{ proposal_form|crispy }}
-        </fieldset>
+        {{ proposal_form|crispy }}
         <div class="form-group form-actions">
             <p>
                 You will be able to edit your proposal after it has been submitted. The program committee may ask questions, provide feedback, and even suggest changes to your proposal as part of the review processes.

--- a/conf_site/templates/symposion/speakers/speaker_create.html
+++ b/conf_site/templates/symposion/speakers/speaker_create.html
@@ -9,10 +9,7 @@
     <h1>{% translate "Create Speaker Profile" %}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {{ speaker_form|crispy }}
-        </fieldset>
+        {{ speaker_form|crispy }}
         <div class="form-actions">
             <input class="btn btn-base-color" type="submit" value="Save" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>

--- a/conf_site/templates/symposion/speakers/speaker_edit.html
+++ b/conf_site/templates/symposion/speakers/speaker_edit.html
@@ -9,10 +9,7 @@
     <h1>{% translate "Edit Speaker Profile" %}</h1>
     <form method="POST" action="" enctype="multipart/form-data">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {{ speaker_form|crispy }}
-        </fieldset>
+        {{ speaker_form|crispy }}
         <div class="form-actions">
             <input class="btn btn-base-color" type="submit" value="Save" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>

--- a/conf_site/templates/symposion/sponsorship/add.html
+++ b/conf_site/templates/symposion/sponsorship/add.html
@@ -12,10 +12,7 @@
     <h1>{% translate "Add a Sponsor" %}</h1>
     <form method="POST" action="{% url "sponsor_add" %}" class="form-horizontal">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {% crispy form %}
-        </fieldset>
+        {% crispy form %}
         <div class="form-actions">
             <input class="btn btn-base-color" type="submit" value="Add" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>

--- a/conf_site/templates/symposion/sponsorship/apply.html
+++ b/conf_site/templates/symposion/sponsorship/apply.html
@@ -14,10 +14,7 @@
 
     <form method="POST" action="" class="form-horizontal">
         {% csrf_token %}
-        <fieldset>
-            <legend>An asterisk (<span style="color:red;font-weight:bold">*</span>) indicates a required field.</legend>
-            {% crispy form %}
-        </fieldset>
+        {% crispy form %}
         <div class="form-actions">
             <input class="btn btn-base-color" type="submit" value="Apply" />
             <a class="btn btn-default" href="{% url "dashboard" %}">Cancel</a>


### PR DESCRIPTION
Contrary to aa4ee5ad28ec6ace80b4069ca961c8f0b3e5c8b1, we cannot define pseudo-attributes in inline CSS.