### PR TITLE
Pin cryptography to versions below 3.4.

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,4 @@
+cryptography<3.4
 django==3.1.7
 django-allauth==0.42.0
 django-analytical==2.6.0


### PR DESCRIPTION
Pin cryptography to versions below 3.4 so that we do not need to install Rust. This should be removed if/when we start using wheels again.