### PR TITLE
Remove "[site_name]" from account-related emails.

### DIFF
--- a/conf_site/templates/account/email/email_confirmation_subject.txt
+++ b/conf_site/templates/account/email/email_confirmation_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktranslate with site_name=current_site.name %}[{{ site_name }}] Confirm your email address{% endblocktranslate %}
+Confirm your email address

--- a/conf_site/templates/account/email/invite_user_subject.txt
+++ b/conf_site/templates/account/email/invite_user_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktranslate with site_name=current_site.name %}[{{ site_name }}] Create an account{% endblocktranslate %}
+Create an account

--- a/conf_site/templates/account/email/password_change_subject.txt
+++ b/conf_site/templates/account/email/password_change_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktranslate with site_name=current_site.name %}[{{ site_name }}] Password change notification{% endblocktranslate %}
+Password change notification

--- a/conf_site/templates/account/email/password_reset_subject.txt
+++ b/conf_site/templates/account/email/password_reset_subject.txt
@@ -1,1 +1,1 @@
-{% load i18n %}{% blocktranslate with site_name=current_site.name %}[{{ site_name }}] Password reset{% endblocktranslate %}
+Password reset


### PR DESCRIPTION
Remove "[site_name]" from subject of account-related messages so the subject does not contain two site names (since the default
`ACCOUNT_EMAIL_SUBJECT_PREFIX` setting is used).