### PR TITLE
Remove sponsors folder from nginx config.

### DIFF
--- a/ansible/roles/web/templates/_django_subfolders.j2
+++ b/ansible/roles/web/templates/_django_subfolders.j2
@@ -72,11 +72,6 @@ location {{ subdirectory }}/speaker/ {
     {% include "./templates/_proxy_variables.j2" %}
 }
 
-location {{ subdirectory }}/sponsors/ {
-    proxy_pass http://127.0.0.1:{{ gunicorn_port }};
-    {% include "./templates/_proxy_variables.j2" %}
-}
-
 location {{ subdirectory }}/time-zone/ {
     proxy_pass http://127.0.0.1:{{ gunicorn_port }};
     {% include "./templates/_proxy_variables.j2" %}


### PR DESCRIPTION
Remove sponsors folder from nginx configuration file, since integration has been removed (see #899). Keeping this would prevent the WordPress content management site from having a /sponsors/ directory.