### PR TITLE
Remove django-reversion.

### DIFF
--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -112,7 +112,6 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "conf_site.core.middleware.TimeZoneMiddleware",
-    "reversion.middleware.RevisionMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
@@ -143,7 +142,6 @@ INSTALLED_APPS = [
     "easy_thumbnails",
     "pinax.eventlog",
     "rest_framework",
-    "reversion",
     "symposion",
     "symposion.conference",
     "symposion.proposals",

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -9,7 +9,6 @@ django-model-utils==4.1.1
 django-multiselectfield==0.1.12
 django-redis-cache==3.0.0
 djangorestframework==3.12.4
-django-reversion==3.0.9
 django-taggit==1.2.0
 django-timezone-field==4.2.1
 easy-thumbnails==2.7.1

--- a/symposion/proposals/models.py
+++ b/symposion/proposals/models.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.exceptions import ValidationError
 
 from model_utils.managers import InheritanceManager
-from reversion import revisions as reversion
 
 from symposion.markdown_parser import parse
 from symposion.conference.models import Section
@@ -194,9 +193,6 @@ class ProposalBase(models.Model):
 
     def __str__(self):
         return self.title
-
-
-reversion.register(ProposalBase)
 
 
 class AdditionalSpeaker(models.Model):

--- a/symposion/schedule/tests/runtests.py
+++ b/symposion/schedule/tests/runtests.py
@@ -17,7 +17,6 @@ try:
             "django.contrib.auth",
             "django.contrib.contenttypes",
             "django.contrib.sites",
-            "reversion",
             "symposion",
             "symposion.conference",
             "symposion.speakers",


### PR DESCRIPTION
Remove django-reversion, since it was not configured properly to expose revision functionality.