### PR TITLE
Private reviewing

### DIFF
--- a/conf_site/reviews/tests/test_proposal_detail_view.py
+++ b/conf_site/reviews/tests/test_proposal_detail_view.py
@@ -118,8 +118,8 @@ class ProposalDetailViewAccessTestCase(ReviewingTestCase, AccountsTestCase):
         )
         self.assertContains(response, "div-proposal-result-buttons")
 
-    def test_reviewer_cannot_view_other_reviewers_names(self):
-        """Verify that a reviewer cannot view other reviewers' names."""
+    def test_reviewer_cannot_view_other_reviews(self):
+        """Verify that a reviewer cannot view other reviewers or reviews."""
         other_vote = ProposalVoteFactory(proposal=self.proposal)
         other_feedback = ProposalFeedbackFactory.create(proposal=self.proposal)
 
@@ -135,6 +135,13 @@ class ProposalDetailViewAccessTestCase(ReviewingTestCase, AccountsTestCase):
 
             self.assertNotContains(response, other_feedback.author.username)
             self.assertNotContains(response, other_feedback.author.email)
+
+        with override_config(PRIVATE_REVIEWS=True):
+            response = self.client.get(
+                reverse(self.reverse_view_name, args=self.reverse_view_args)
+            )
+            self.assertNotContains(response, other_vote.comment_html)
+            self.assertNotContains(response, other_feedback.comment_html)
 
     def _test_button_text(self, good_text, bad_text):
         self._add_to_reviewers_group()

--- a/conf_site/reviews/tests/test_proposal_feedback_posting.py
+++ b/conf_site/reviews/tests/test_proposal_feedback_posting.py
@@ -67,3 +67,16 @@ class ProposalFeedbackPostingTestCase(
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(mail.outbox[0].to, [random_user.email])
         self.assertFalse(self._duplicate_email_addresses(mail.outbox[0]))
+
+    def test_do_not_send_updates_to_reviewers_during_private_reviewing(self):
+        self._add_to_reviewers_group()
+        random_user = UserFactory()
+        ProposalFeedbackFactory(proposal=self.proposal, author=random_user)
+
+        response = self._get_response()
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(len(mail.outbox), 2)
+        self.assertNotEqual(mail.outbox[0].to, [random_user.email])
+        self.assertNotEqual(mail.outbox[0].cc, [random_user.email])
+        self.assertNotEqual(mail.outbox[0].bcc, [random_user.email])

--- a/conf_site/reviews/tests/test_proposal_list_view.py
+++ b/conf_site/reviews/tests/test_proposal_list_view.py
@@ -5,11 +5,13 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 
+from constance.test import override_config
 from faker import Faker
 
 from symposion.proposals.models import AdditionalSpeaker
 from symposion.schedule.tests.factories import (
-    ProposalKindFactory, SectionFactory
+    ProposalKindFactory,
+    SectionFactory,
 )
 
 from conf_site.accounts.tests import AccountsTestCase
@@ -220,3 +222,14 @@ class ProposalListViewTestCase(ReviewingTestCase, AccountsTestCase):
             "and has not been notified.".format(emailless_speaker.name)
         )
         self.assertContains(response, speaker_warning)
+
+    def test_private_reviewing_means_no_score_columns(self):
+        self._add_to_reviewers_group()
+        with override_config(PRIVATE_REVIEWS=True):
+            response = self.client.get(
+                reverse(self.reverse_view_name, args=self.reverse_view_args)
+            )
+        self.assertNotContains(response, "<th>+1</th>")
+        self.assertNotContains(response, "<th>+0</th>")
+        self.assertNotContains(response, "<th>-0</th>")
+        self.assertNotContains(response, "<th>-1</th>")

--- a/conf_site/settings/base.py
+++ b/conf_site/settings/base.py
@@ -232,6 +232,11 @@ CONSTANCE_CONFIG = {
         "Hide identities of authors from reviewers.",
         bool,
     ),
+    "PRIVATE_REVIEWS": (
+        False,
+        "Hide content of reviews from other reviewers.",
+        bool,
+    ),
     "PROPOSAL_EDITING_WHEN_CFP_IS_CLOSED": (
         True,
         "If submitters can make changes to a proposal if the CFP is closed.",
@@ -256,7 +261,9 @@ CONSTANCE_CONFIG_FIELDSETS = {
         "PROPOSAL_URL_FIELDS",
         "PROPOSALS_PER_PAGE",
     ),
-    "Reviewing Options": ("BLIND_AUTHORS", "BLIND_REVIEWERS"),
+    "Reviewing Options": (
+        "BLIND_AUTHORS", "BLIND_REVIEWERS", "PRIVATE_REVIEWS"
+    ),
 }
 CRISPY_TEMPLATE_PACK = "bootstrap3"
 CSRF_FAILURE_VIEW = "conf_site.core.views.csrf_failure"

--- a/conf_site/templates/reviews/_proposal_feedback_tab.html
+++ b/conf_site/templates/reviews/_proposal_feedback_tab.html
@@ -8,8 +8,10 @@
       {% else %}
         <b>{{ feedback.author.get_full_name|default:feedback.author.username }}</b>:
       {% endif %}
-      {{ feedback.comment_html|safe }}
-    {% endfor %}
+      {% if request.user.is_superuser or not config.PRIVATE_REVIEWS or actor == "speaker" or feedback.author == proposal.speaker.user or feedback.author == request.user %}
+        {{ feedback.comment_html|safe }}
+      {% endif %}
+    </p>{% endfor %}
       <form method="POST" action="{% url 'review_proposal_feedback' proposal.id %}" class="review-form">
         <legend>Write Feedback:</legend>
         {% csrf_token %}

--- a/conf_site/templates/reviews/proposal_detail.html
+++ b/conf_site/templates/reviews/proposal_detail.html
@@ -11,12 +11,16 @@
   {% endif %}
   <h2>{{ proposal.title }}</h2>
 
-  {% if config.BLIND_REVIEWERS and request.user.is_superuser %}
-    <p class="bg-info">
-      Your superuser status is ignoring the enabled
-      <strong>BLIND_REVIEWERS</strong> setting.
-    </p>
-  {% endif %}
+  <p class="bg-info">
+    {% if config.BLIND_REVIEWERS and request.user.is_superuser %}
+        Your superuser status is ignoring the enabled
+        <strong>BLIND_REVIEWERS</strong> setting.
+    {% endif %}
+    {% if config.PRIVATE_REVIEWS and request.user.is_superuser %}
+        Your superuser status is ignoring the enabled
+        <strong>PRIVATE_REVIEWS</strong> setting.
+    {% endif %}
+  </p>
 
   <div class="pull-right" style="margin-top:-3rem">
     {% if not proposal.cancelled %}
@@ -60,7 +64,9 @@
       <li>
         <a href="#proposal-feedback" data-toggle="tab">
           {% translate "Speaker Feedback" %}
-          <span class="badge">{{ proposal.feedback_count }}</span>
+          {% if request.user.is_superuser or not config.PRIVATE_REVIEWS %}
+            <span class="badge">{{ proposal.feedback_count }}</span>
+          {% endif %}
         </a>
       </li>
     </ul>
@@ -71,7 +77,8 @@
     {# Only show reviews if user is a reviewer. #}
     {% if actor == "reviewer" %}<div class="tab-pane" id="proposal-reviews">
       <h3>Votes</h3>
-      {% for review_vote in proposal.review_votes.all %}<hr><p>
+      {% for review_vote in proposal.review_votes.all %}
+      {% if request.user.is_superuser or not config.PRIVATE_REVIEWS or review_vote.voter == request.user %}<hr><p>
         <h4>
           {% if not request.user.is_superuser and config.BLIND_REVIEWERS and review_vote.voter != request.user %}
             Anonymous
@@ -81,7 +88,8 @@
           ({{ review_vote.get_score_display }})
         </h4>
         {{ review_vote.comment_html|safe }}
-      </p>{% endfor %}
+      </p>{% endif %}
+      {% endfor %}
       <form method="POST" action="{% url 'review_proposal_vote' proposal.id %}" class="review-form">
         <legend>{% if existing_vote %}{% translate 'Update Review' %}{% else %}{% translate 'Submit Review' %}{% endif %}</legend>
         <p>

--- a/conf_site/templates/reviews/proposal_list.html
+++ b/conf_site/templates/reviews/proposal_list.html
@@ -8,12 +8,16 @@
 <div class="container">
   {% include "reviews/_proposal_mini_navigation.html" %}
   <h2>{% block page-title %}{{ proposal_category }} {{ proposal_kind }}s{% endblock %}</h2>
+  <p class="bg-info">
   {% if config.BLIND_REVIEWERS and request.user.is_superuser %}
-    <p class="bg-info">
       Your superuser status is ignoring the enabled
       <strong>BLIND_REVIEWERS</strong> setting.
-    </p>
   {% endif %}
+  {% if config.PRIVATE_REVIEWS and request.user.is_superuser %}
+      Your superuser status is ignoring the enabled
+      <strong>PRIVATE_REVIEWS</strong> setting.
+  {% endif %}
+</p>
   <p>
     <strong>{{ num_proposals }}</strong> proposal{{ num_proposals|pluralize }}
     (<strong>{{ num_talks }}</strong> talk{{ num_talks|pluralize }},
@@ -37,10 +41,12 @@
       <th>{% translate "Title" %}</th>
       <th>{% translate "Category" %}</th>
       <th><i class="fa fa-comment" title="{% translate 'Number of Messages' %}"></i></th>
+      {% if not config.PRIVATE_REVIEWS or request.user.is_superuser %}
       <th>{% translate "+1" %}</th>
       <th>{% translate "+0" %}</th>
       <th>{% translate "-0" %}</th>
       <th>{% translate "-1" %}</th>
+      {% endif %}
       <th><i class="fa fa-hashtag" title="{% translate 'Total Number of Reviews' %}"></i></th>
       <th class="sorter-user-scores"><a href="#" class="tip" title="{% translate 'Your Rating' %}"><i class="fa fa-user"></i></a></th>
       <th>{% translate "Status" %}</th>
@@ -61,10 +67,12 @@
         </td>
         <td>{{ proposal.kind.name }}</td>
         <td>{{ proposal.feedback_count }}</td>
+        {% if not config.PRIVATE_REVIEWS or request.user.is_superuser %}
         <td>{{ proposal.plus_one }}</td>
         <td>{{ proposal.plus_zero }}</td>
         <td>{{ proposal.minus_zero }}</td>
         <td>{{ proposal.minus_one }}</td>
+        {% endif %}
         <td>{{ proposal.total_votes }}</td>
         <td>{% user_score proposal request.user %}</td>
         <td>

--- a/docs/source/reviewing.rst
+++ b/docs/source/reviewing.rst
@@ -9,8 +9,9 @@ To review proposals, conference site users must be a member of the
 site's administration section) need to add users to this group in order for
 them to have access.
 
-Two dynamic settings (`BLIND_AUTHORS` and `BLIND_REVIEWERS`) determine the
-type of reviewing system:
+Three dynamic settings
+(`BLIND_AUTHORS`, `BLIND_REVIEWERS`, and `PRIVATE_REVIEWS`)
+determine the type of reviewing system:
 
   - **`BLIND_AUTHORS` is True and `BLIND_REVIEWERS` is False**:
     Authors cannot see the identities of reviewers, but
@@ -23,8 +24,11 @@ type of reviewing system:
   - **`BLIND_AUTHORS` is False and `BLIND_REVIEWERS` is True**:
     Authors can see reviewers' identities, but reviewers cannot see the
     identities of authors or other reviewers.
+  - **`PRIVATE_REVIEWS` is True**:
+    Reviewers cannot see other reviewers' scores or comments.
+    This setting is best used with `BLIND_REVIEWERS`.
 
-`BLIND_AUTHORS` is True and `BLIND_REVIEWERS` is False by default.
+`BLIND_AUTHORS` is True. All other settings are False by default.
 Like other dynamic settings, the reviewing settings
 can be modified from their defaults
 by editing them on the Constance Config page in the Django admin.

--- a/docs/source/reviewing.rst
+++ b/docs/source/reviewing.rst
@@ -9,22 +9,24 @@ To review proposals, conference site users must be a member of the
 site's administration section) need to add users to this group in order for
 them to have access.
 
-Two dynamic settings (BLIND_AUTHORS and BLIND_REVIEWERS) determine whether the
+Two dynamic settings (`BLIND_AUTHORS` and `BLIND_REVIEWERS`) determine the
 type of reviewing system:
 
-  - **single blind** - `BLIND_AUTHORS` is True and `BLIND_REVIEWERS` is False.
+  - **`BLIND_AUTHORS` is True and `BLIND_REVIEWERS` is False**:
     Authors cannot see the identities of reviewers, but
     reviewers can see authors' identities.
-  - **double blind** - both `BLIND_AUTHORS` and `BLIND_REVIEWERS` are True.
-    Neither authors nor reviewers can see each others' identities.
-  - **open** - both `BLIND_AUTHORS` and `BLIND_REVIEWERS` are False.
+  - **both `BLIND_AUTHORS` and `BLIND_REVIEWERS` are True**:
+    Authors cannot see reviewers' identities and reviewers cannot see the
+    identities of authors or other reviewers.
+  - **both `BLIND_AUTHORS` and `BLIND_REVIEWERS` are False**:
     Both authors and reviewers can see each others' identities.
-  - **reverse blind** - `BLIND_AUTHORS` is False and `BLIND_REVIEWERS` is True.
+  - **`BLIND_AUTHORS` is False and `BLIND_REVIEWERS` is True**:
     Authors can see reviewers' identities, but reviewers cannot see the
-    identities of authors.
+    identities of authors or other reviewers.
 
-Single blind reviewing is the default. Like other dynamic settings,
-BLIND_AUTHORS and BLIND_REVIEWERS can be modified from their defaults
+`BLIND_AUTHORS` is True and `BLIND_REVIEWERS` is False by default.
+Like other dynamic settings, the reviewing settings
+can be modified from their defaults
 by editing them on the Constance Config page in the Django admin.
 
 Messaging


### PR DESCRIPTION
Add `PRIVATE_REVIEWS` dynamic setting to optionally prevent reviewers from seeing other reviewers' votes and feedback messages.