### PR TITLE
Show error if non-CSV file is uploaded to CSV import view

### DIFF
--- a/conf_site/core/forms.py
+++ b/conf_site/core/forms.py
@@ -5,3 +5,23 @@ class CsvUploadForm(forms.Form):
     """Form for uploading a CSV file."""
 
     csv_file = forms.FileField(label="Please upload a CSV file.")
+
+    def _is_csv_file(self, file_data):
+        """
+        Test whether an uploaded file is a CSV file.
+
+        Returns a list of a boolean of the results and the uploaded content
+        type.
+        """
+        uploaded_content_type = getattr(file_data, "content_type", "text/csv")
+        return [uploaded_content_type == "text/csv", uploaded_content_type]
+
+    def clean_csv_file(self, *args, **kwargs):
+        data = super().clean(*args, **kwargs)
+        results = self._is_csv_file(data["csv_file"])
+        if not results[0]:
+            raise forms.ValidationError(
+                "Only CSV files ('text/csv') can be uploaded with this form. "
+                "You uploaded a '{}' file.".format(results[1])
+            )
+        return data

--- a/conf_site/core/views.py
+++ b/conf_site/core/views.py
@@ -81,11 +81,11 @@ class CsvImportView(FormView):
     def post(self, request, *args, **kwargs):
         form = self.get_form(self.get_form_class())
         if form.is_valid():
-            excel_file = request.FILES["csv_file"]
+            csv_file = request.FILES["csv_file"]
             # Save file to temporary folder. We only need it for
             # a short period of time.
             temp_file, filename = mkstemp(suffix=".csv")
-            for chunk in excel_file.chunks():
+            for chunk in csv_file.chunks():
                 os.write(temp_file, chunk)
             os.fsync(temp_file)
             os.close(temp_file)


### PR DESCRIPTION
Add cleaning method to CsvUploadForm to ensure that uploaded file has either the mimetype for a CSV file (`text/csv`) or no mimetype. Return validation error if user uploads a file with a different mimetype.