### PR TITLE
Remove outline from presentation page.

### DIFF
--- a/conf_site/templates/symposion/schedule/presentation_detail.html
+++ b/conf_site/templates/symposion/schedule/presentation_detail.html
@@ -33,10 +33,6 @@
 
     <div class="description">{{ presentation.description_html|safe }}</div>
 
-    <h3>Outline</h3>
-
-    <div>{{ presentation.outline_html|safe }}</div>
-
     <h3>Description</h3>
 
     <div class="abstract">{{ presentation.abstract_html|safe }}</div>


### PR DESCRIPTION
Remove HTML version of outline from presentation page because it was optional in the proposal form.