### PR TITLE
schedule coloring

### DIFF
--- a/conf_site/static/css/custom.css
+++ b/conf_site/static/css/custom.css
@@ -103,7 +103,8 @@ input[type="checkbox"] {
 }
 
 table.calendar tr{min-height:36px}
-table.calendar th{text-align:center}table.calendar th.time{width:60px}
+table.calendar th{background-color:#ee9041;text-align:center}
+table.calendar th.time{width:60px}
 table.calendar td{text-align:center;vertical-align:middle}
 table.calendar td p {font-size:14px;}
 table.calendar td.time{vertical-align:top;padding-top:0;margin-top:0;color:#444;font-size:11px}

--- a/conf_site/static/css/custom.css
+++ b/conf_site/static/css/custom.css
@@ -111,7 +111,9 @@ table.calendar td.time{vertical-align:top;padding-top:0;margin-top:0;color:#444;
 table.calendar td.slot{font-weight:bold;text-shadow:#fff 0 1px 0;vertical-align:middle}
 /* Colors for different slot kinds. Currently disabled.
 table.calendar td.slot.slot-break{background-color:#ecffff}
-table.calendar td.slot.slot-plenary{background-color:#ffffcc}
+*/
+table.calendar td.slot.slot-plenary{background-color:#e1edf7}
+/*
 table.calendar td.slot.slot-talk{background-color:#e1edf7}
 table.calendar td.slot.slot-tutorial{background-color:#fbe5d4}
 table.calendar td.slot.slot-discussion{background-color:#b8d9e3}

--- a/conf_site/templates/symposion/schedule/_grid.html
+++ b/conf_site/templates/symposion/schedule/_grid.html
@@ -12,7 +12,7 @@
             <tr>
                 <td class="time">{{ row.time }}</td>
                 {% for slot in row.slots %}
-                    <td class="slot slot-{{ slot.content.proposal.kind.slug }}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
+                    <td class="slot slot-{% if slot.content.proposal %}{{ slot.content.proposal.kind.slug }}{% else %}{{ slot.kind.label|lower }}{% endif %}" colspan="{{ slot.colspan }}" rowspan="{{ slot.rowspan }}">
                       {% if slot.content %}
                           <span class="title">
                                 <a href="{% url "schedule_presentation_detail" slot.content.pk slot.content.slug %}">


### PR DESCRIPTION
  - Generate CSS classes for contentless slots.
  - Add orange background to schedule headings.
  - Make plenary slots blue.