### PR TITLE
Remove link to past event schedules.

### DIFF
--- a/conf_site/templates/symposion/schedule/schedule_conference.html
+++ b/conf_site/templates/symposion/schedule/schedule_conference.html
@@ -15,7 +15,6 @@
     <div class="page-head">
         <h1>Conference Schedule</h1>
     </div>
-    <p>View past PyData event schedules <a href="https://pydata.org/past-events.html" title="Past PyData Events">here</a>.</p>
     {% for section in sections %}
             {% for timetable in section.days %}
                 <h3>{{ section.schedule.section.name }}</h3>

--- a/conf_site/templates/symposion/schedule/schedule_detail.html
+++ b/conf_site/templates/symposion/schedule/schedule_detail.html
@@ -15,7 +15,6 @@
     <div class="page-head">
         <h1>{{ schedule.section }} Schedule</h1>
     </div>
-    <p>View past PyData event schedules <a href="https://pydata.org/past-events.html" title="Past PyData Events">here</a>.</p>
     {% for timetable in days %}
         <h3>{{ timetable.day.date }}</h3>
         {% include "symposion/schedule/_grid.html" %}


### PR DESCRIPTION
Remove link to past schedules on pydata.org from schedule pages.