### PR TITLE
Remove yamllint extra from ansible-lint

### DIFF
--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,10 +1,10 @@
-- name: restart fail2ban
+- name: Restart fail2ban
   ansible.builtin.service:
     name: fail2ban
     state: restarted
   become: true
 
-- name: restart supervisor
+- name: Restart supervisor
   ansible.builtin.service:
     name: supervisor
     state: restarted

--- a/ansible/roles/common/tasks/apt.yml
+++ b/ansible/roles/common/tasks/apt.yml
@@ -1,17 +1,17 @@
-- name: install python3-apt
+- name: Install python3-apt
   ansible.builtin.apt:
     pkg: python3-apt
     state: present
   become: true
 
-- name: update package list & upgrade existing packages
+- name: Update package list & upgrade existing packages
   ansible.builtin.apt:
     cache_valid_time: 3600
     update_cache: true
     upgrade: true
   become: true
 
-- name: install common packages
+- name: Install common packages
   ansible.builtin.apt:
     name:
       - git
@@ -25,14 +25,14 @@
     state: present
   become: true
 
-- name: copy apt configuration file (20auto-upgrades)
+- name: Copy apt configuration file (20auto-upgrades)
   ansible.builtin.template:
     dest: "/etc/apt/apt.conf.d/20auto-upgrades"
     mode: 0644
     src: 20auto-upgrades
   become: true
 
-- name: copy apt configuration file (50unattended-upgrades)
+- name: Copy apt configuration file (50unattended-upgrades)
   ansible.builtin.template:
     dest: "/etc/apt/apt.conf.d/50unattended-upgrades"
     mode: 0644

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: apt.yml
-- include: security.yml
+- import_tasks: apt.yml
+- import_tasks: security.yml

--- a/ansible/roles/common/tasks/security.yml
+++ b/ansible/roles/common/tasks/security.yml
@@ -1,4 +1,4 @@
-- name: install fail2ban
+- name: Install fail2ban
   ansible.builtin.apt:
     pkg: fail2ban
     state: present

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: install PostgreSQL packages
+- name: Install PostgreSQL packages
   ansible.builtin.apt:
     name:
       - libpq-dev
@@ -7,7 +7,7 @@
     state: present
   become: true
 
-- name: create a PostgreSQL database for this project
+- name: Create a PostgreSQL database for this project
   become: true
   become_user: postgres
   ansible.builtin.postgresql_db:
@@ -16,7 +16,7 @@
     state: present
     template: template0
 
-- name: create a PostgreSQL user for this project
+- name: Create a PostgreSQL user for this project
   become: true
   become_user: postgres
   ansible.builtin.postgresql_user:

--- a/ansible/roles/web/handlers/main.yml
+++ b/ansible/roles/web/handlers/main.yml
@@ -1,16 +1,16 @@
-- name: restart redis
+- name: Restart redis
   ansible.builtin.service:
     name: redis-server
     state: restarted
   become: true
 
-- name: restart nginx
+- name: Restart nginx
   ansible.builtin.service:
     name: nginx
     state: restarted
   become: true
 
-- name: delete other virtualenvs
+- name: Delete other virtualenvs
   ansible.builtin.shell: find  -maxdepth 1
          ! -path '.'
          ! -path './'$(basename $(readlink current))
@@ -19,13 +19,13 @@
   args:
     chdir: "{{ virtualenv_root }}"
 
-- name: restart gunicorn
+- name: Restart gunicorn
   ansible.builtin.supervisorctl:
     name: gunicorn
     state: restarted
   become: true
 
-- name: mark fixtures as applied
+- name: Mark fixtures as applied
   ansible.builtin.file:
     path: "{{ project_root }}/fixtures/.applied"
     state: touch

--- a/ansible/roles/web/handlers/main.yml
+++ b/ansible/roles/web/handlers/main.yml
@@ -33,4 +33,4 @@
   tags:
     - fixtures
 
-- include: sentry.yml
+- import_tasks: sentry.yml

--- a/ansible/roles/web/handlers/sentry.yml
+++ b/ansible/roles/web/handlers/sentry.yml
@@ -1,4 +1,4 @@
-- name: create new Sentry release
+- name: Create new Sentry release
   ansible.builtin.uri:
     body: "{'projects': ['{{ sentry_project_name }}'], 'version': '{{ git_status.stdout }}'}"
     body_format: "json"
@@ -9,7 +9,7 @@
     status_code: 201, 208
     url: "https://sentry.io/api/0/organizations/{{ application_owner }}/releases/"
 
-- name: send Sentry notification of deployment
+- name: Send Sentry notification of deployment
   ansible.builtin.uri:
     body: "{'environment': '{{ environment_type }}'}"
     body_format: "json"

--- a/ansible/roles/web/tasks/django.yml
+++ b/ansible/roles/web/tasks/django.yml
@@ -1,4 +1,4 @@
-- name: pull repository from Github to project directory
+- name: Pull repository from Github to project directory
   ansible.builtin.git:
     accept_hostkey: true
     dest: "{{ project_root }}"
@@ -8,12 +8,12 @@
   become: true
   when: environment_type != "development"
   notify:
-    - restart nginx
-    - restart gunicorn
-    - create new Sentry release
-    - send Sentry notification of deployment
+    - Restart nginx
+    - Restart gunicorn
+    - Create new Sentry release
+    - Send Sentry notification of deployment
 
-- name: install python packages and associated libraries
+- name: Install python packages and associated libraries
   ansible.builtin.apt:
     name:
       - gettext
@@ -31,9 +31,9 @@
       - zlib1g-dev
     state: present
   become: true
-  notify: restart gunicorn
+  notify: Restart gunicorn
 
-- name: change ownership of everything to this user
+- name: Change ownership of everything to this user
   ansible.builtin.file:
     path: "{{ project_root }}"
     recurse: true
@@ -41,70 +41,70 @@
     group: www-data
   become: true
 
-- name: manually figure out latest Git commit
+- name: Manually figure out latest Git commit
   ansible.builtin.command: git rev-parse HEAD chdir={{ project_root }}
   register: git_status
   tags:
     - skip_ansible_lint
 
-- name: determine if virtualenv exists
+- name: Determine if virtualenv exists
   ansible.builtin.stat:
     path: "{{ virtualenv_root }}/{{ git_status.stdout }}"
   register: venv_dir
 
-- name: create virtualenv if necessary
+- name: Create virtualenv if necessary
   ansible.builtin.command: >
     python3 -m virtualenv -p python3 {{ virtualenv_root }}/{{ git_status.stdout }}
   when: venv_dir.stat.isdir is not defined
-  notify: delete other virtualenvs
+  notify: Delete other virtualenvs
   tags:
     - skip_ansible_lint
 
-- name: get target of old "current" virtualenv symlink
+- name: Get target of old "current" virtualenv symlink
   ansible.builtin.stat:
     path: "{{ virtualenv_root }}/current"
   register: old_current_virtualenv
 
-- name: add/update "previous" virtualenv symlink
+- name: Add/update "previous" virtualenv symlink
   ansible.builtin.file:
     path: "{{ virtualenv_root }}/previous"
     src: "{{ old_current_virtualenv.stat.lnk_source }}"
     state: link
   when: venv_dir.stat.isdir is not defined and old_current_virtualenv.stat.islnk is true
 
-- name: add/update "current" virtualenv symlink
+- name: Add/update "current" virtualenv symlink
   ansible.builtin.file:
     state: link
     path: "{{ virtualenv_root }}/current"
     src: "{{ virtualenv_root }}/{{ git_status.stdout }}"
 
-- name: use symlink for easier virtualenv management
+- name: Use symlink for easier virtualenv management
   ansible.builtin.file:
     path: "{{ virtualenv_root }}/current"
     src: "{{ virtualenv_root }}/{{ git_status.stdout }}"
     state: link
 
-- name: install latest version of pip
+- name: Install latest version of pip
   ansible.builtin.pip:
     extra_args: "--upgrade"
     name: pip
     state: present
     virtualenv: "{{ virtualenv_root }}/current"
 
-- name: update virtualenv with requirements
+- name: Update virtualenv with requirements
   ansible.builtin.pip:
     extra_args: "--upgrade"
     requirements: "{{ project_root }}/requirements/{{ environment_type }}.txt"
     state: present
     virtualenv: "{{ virtualenv_root }}/current"
-  notify: restart gunicorn
+  notify: Restart gunicorn
 
-- name: add supervisor configuration file for gunicorn
+- name: Add supervisor configuration file for gunicorn
   ansible.builtin.template:
     dest: "/etc/supervisor/conf.d/gunicorn.conf"
     mode: 0644
     src: supervisor.conf
   become: true
   notify:
-    - restart supervisor
-    - restart gunicorn
+    - Restart supervisor
+    - Restart gunicorn

--- a/ansible/roles/web/tasks/letsencrypt.yml
+++ b/ansible/roles/web/tasks/letsencrypt.yml
@@ -1,11 +1,11 @@
-- name: install certbot
+- name: Install certbot
   ansible.builtin.apt:
     name: certbot
     state: present
   become: true
   when: ssl_enabled
 
-- name: create .well-known directory
+- name: Create .well-known directory
   ansible.builtin.file:
     mode: 0755
     path: "{{ project_root }}/.well-known"
@@ -16,7 +16,7 @@
 # We use the "standalone" method because nginx needs a certificate to run,
 # so the webroot method will not work when we provision the certificate for
 # the first time.
-- name: run certbot and generate certificate
+- name: Run certbot and generate certificate
   ansible.builtin.command: >
     certbot certonly -n --standalone --agree-tos
     -d {{ website_domain }}

--- a/ansible/roles/web/tasks/main.yml
+++ b/ansible/roles/web/tasks/main.yml
@@ -1,5 +1,5 @@
-- include: redis.yml
-- include: nginx.yml
-- include: letsencrypt.yml
-- include: django.yml
-- include: pretalx.yml
+- import_tasks: redis.yml
+- import_tasks: nginx.yml
+- import_tasks: letsencrypt.yml
+- import_tasks: django.yml
+- import_tasks: pretalx.yml

--- a/ansible/roles/web/tasks/nginx.yml
+++ b/ansible/roles/web/tasks/nginx.yml
@@ -1,36 +1,36 @@
-- name: add nginx package key
+- name: Add nginx package key
   ansible.builtin.apt_key:
     id: 7BD9BF62
     state: present
     url: http://nginx.org/keys/nginx_signing.key
   become: true
 
-- name: add mainline nginx repository
+- name: Add mainline nginx repository
   ansible.builtin.apt_repository:
     repo: "deb http://nginx.org/packages/mainline/debian/ {{ ansible_lsb.codename }} nginx"
     state: present
   become: true
 
-- name: update package list to get latest nginx
+- name: Update package list to get latest nginx
   ansible.builtin.apt:
     update_cache: true
   become: true
 
-- name: install nginx
+- name: Install nginx
   ansible.builtin.apt:
     pkg: nginx
     state: present
   become: true
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: remove default nginx global configuration file
+- name: Remove default nginx global configuration file
   ansible.builtin.file:
     path: "/etc/nginx/nginx.conf"
     state: absent
   become: true
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: add customized nginx global configuration file
+- name: Add customized nginx global configuration file
   ansible.builtin.template:
     dest: "/etc/nginx/nginx.conf"
     force: true
@@ -39,15 +39,15 @@
     owner: root
     src: nginx-global.conf
   become: true
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: remove default nginx site configuration file
+- name: Remove default nginx site configuration file
   ansible.builtin.file:
     path: "/etc/nginx/conf.d/default.conf"
     state: absent
   become: true
 
-- name: add customized http nginx site configuration file
+- name: Add customized http nginx site configuration file
   ansible.builtin.template:
     dest: "/etc/nginx/conf.d/{{ website_domain }}.conf"
     group: root
@@ -55,10 +55,10 @@
     owner: root
     src: nginx-site-http.conf
   become: true
-  notify: restart nginx
+  notify: Restart nginx
   when: not ssl_enabled or environment_type == "development"
 
-- name: add customized https nginx site configuration file
+- name: Add customized https nginx site configuration file
   ansible.builtin.template:
     dest: "/etc/nginx/conf.d/{{ website_domain }}.conf"
     group: root
@@ -66,17 +66,17 @@
     owner: root
     src: nginx-site-https.conf
   become: true
-  notify: restart nginx
+  notify: Restart nginx
   when: ssl_enabled and environment_type != "development"
 
-- name: remove default nginx ssl site configuration file
+- name: Remove default nginx ssl site configuration file
   ansible.builtin.file:
     path: "/etc/nginx/conf.d/example-ssl.conf"
     state: absent
   become: true
-  notify: restart nginx
+  notify: Restart nginx
 
-- name: add custom logrotate configuration for nginx
+- name: Add custom logrotate configuration for nginx
   ansible.builtin.template:
     dest: "/etc/logrotate.d/nginx"
     group: root

--- a/ansible/roles/web/tasks/pretalx.yml
+++ b/ansible/roles/web/tasks/pretalx.yml
@@ -1,4 +1,4 @@
-- name: create pretalx configuration directory if necessary
+- name: Create pretalx configuration directory if necessary
   ansible.builtin.file:
     mode: 0755
     owner: "{{ ansible_user_id }}"
@@ -6,36 +6,36 @@
     state: "directory"
   become: true
 
-- name: add custom pretalx configuration file
+- name: Add custom pretalx configuration file
   ansible.builtin.template:
     dest: "/etc/pretalx/pretalx.cfg"
     mode: 0644
     owner: "{{ ansible_user_id }}"
     src: "pretalx.cfg.j2"
-  notify: restart gunicorn
+  notify: Restart gunicorn
 
-- name: add custom pretalx template
+- name: Add custom pretalx template
   ansible.builtin.template:
     dest: "{{ project_root }}/pretalx/data/templates/common/base.html"
     mode: 0400
     owner: "{{ ansible_user_id }}"
     src: "pretalx/common/base.html"
 
-- name: database migrate
+- name: Database migrate
   ansible.builtin.command:
     cmd: "{{ virtualenv_root }}/current/bin/python -m pretalx migrate"
-  notify: restart gunicorn
+  notify: Restart gunicorn
   tags:
     - skip_ansible_lint
 
-- name: collect static files
+- name: Collect static files
   ansible.builtin.command:
     cmd: "{{ virtualenv_root }}/current/bin/python -m pretalx rebuild"
-  notify: restart nginx
+  notify: Restart nginx
   tags:
     - skip_ansible_lint
 
-- name: add pretalx cron job
+- name: Add pretalx cron job
   ansible.builtin.cron:
     job: "{{ virtualenv_root }}/current/bin/python -m pretalx runperiodic"
     name: "pretalx runperiodic"

--- a/ansible/roles/web/tasks/redis.yml
+++ b/ansible/roles/web/tasks/redis.yml
@@ -1,7 +1,7 @@
-- name: install redis package
+- name: Install redis package
   ansible.builtin.apt:
     pkg: redis-server
     state: present
   become: true
   notify:
-    - restart redis
+    - Restart redis

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,6 +1,6 @@
 -r staging.txt
 ansible==6.4.0
-ansible-lint[yamllint]==6.7.0
+ansible-lint==6.7.0
 coverage==6.4.4
 factory_boy==3.2.1
 flake8==5.0.4


### PR DESCRIPTION
ansible-lint 6.0.0 made yamllint a direct dependency, so it is no longer necessary to include it in the requirements file.