### PR TITLE
Use pretalx branch with submission type changes

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -13,7 +13,7 @@ easy-thumbnails==2.8.5
 gunicorn==20.1.0
 pinax-eventlog==5.1.1
 pip==23.1.2
--e git+https://github.com/pydata/pretalx@csv-reviewer-assignments#egg=pretalx[redis]&subdirectory=src
+-e git+https://github.com/pydata/pretalx@add-submission-type-to-widget-json#egg=pretalx[redis]&subdirectory=src
 psycopg2==2.9.6
 pytz==2023.3
 sentry-sdk==1.21.0


### PR DESCRIPTION
Switch to pretalx branch with changes to schedule widget that allows only showing a single submission type.