### PR TITLE
Pin lxml below version 5

### DIFF
--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -11,6 +11,7 @@ django-taggit==1.2.0
 django-timezone-field==5.1
 easy-thumbnails==2.8.5
 gunicorn==20.1.0
+lxml<5.0
 pinax-eventlog==5.1.1
 pip==23.1.2
 -e git+https://github.com/pydata/pretalx@add-submission-type-to-widget-json#egg=pretalx[redis]&subdirectory=src


### PR DESCRIPTION
Pin lxml below version 5. lxml 5 is incompatible with inlinestyler, a dependency of the pretalx version currently in use.